### PR TITLE
Bump minimum olaf version to 3.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ black
 build
 isort
 oresat-configs
-oresat-olaf>=3.0.0
+oresat-olaf>=3.1.0
 pylama[all]
 pylama[toml]
 setuptools


### PR DESCRIPTION
For reasons my resolver picked olaf 3.0.0 and that fell over. Current __main__.py imports olaf.ServiceState (f5c4a8cf) but ServiceState was introduced as a top level import only in 3.1.0 (oresat-olaf:4bdb70f)