### PR TITLE
si41xx restart and beacon

### DIFF
--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -39,8 +39,10 @@ class RadiosService(Service):
         )
 
         # gpio pins
+        self._si41xx_nlock_gpio = Gpio("LBAND_LO_nLOCKED", mock_hw)
         self._uhf_tot_ok_gpio = Gpio("UHF_TOT_OK", mock_hw)
         if mock_hw:
+            self._si41xx_nlock_gpio._mock_value = 0
             self._uhf_tot_ok_gpio._mock_value = 1
         self._uhf_tot_clear_gpio = Gpio("UHF_TOT_CLEAR", mock_hw)
         self._radio_enable_gpio = Gpio("RADIO_ENABLE", mock_hw)
@@ -74,7 +76,10 @@ class RadiosService(Service):
             logger.error("tot okay was low, resetting radios")
             self.disable()
             self.enable()
-
+        if not self.is_si41xx_locked:
+            logger.error("si41xx unlocked, resetting lband synth")
+            self._si41xx.stop()
+            self._si41xx.start()
         recv = self._recv_edl_request()
         if recv:
             self.recv_queue.append(recv)
@@ -123,6 +128,14 @@ class RadiosService(Service):
         """bool: check if the UHF TOT is okay."""
 
         return bool(self._uhf_tot_ok_gpio.value)
+
+    @property
+    def is_si41xx_locked(self) -> bool:
+        """bool: check if the si41xx is locked."""
+
+        # si41xx_nlock is active low
+        return not bool(self._si41xx_nlock_gpio.value)
+
 
     def send_beacon(self, message: bytes):
         """Send a beacon."""

--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -134,7 +134,9 @@ class RadiosService(Service):
         """bool: check if the si41xx is locked."""
 
         # si41xx_nlock is active low
-        return not bool(self._si41xx_nlock_gpio.value)
+        state = not bool(self._si41xx_nlock_gpio.value)
+        self.node.od["lband"]["synth_lock"].value = state
+        return state
 
 
     def send_beacon(self, message: bytes):

--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -138,7 +138,6 @@ class RadiosService(Service):
         self.node.od["lband"]["synth_lock"].value = state
         return state
 
-
     def send_beacon(self, message: bytes):
         """Send a beacon."""
 


### PR DESCRIPTION
This monitors the state of the si41xx lock line, updates the OD with the state, and attempts to restart the chip if it loses lock.