### PR TITLE
synth_relock_count as log2

### DIFF
--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -49,6 +49,9 @@ class RadiosService(Service):
         self._uhf_enable_gpio = Gpio("UHF_ENABLE", mock_hw)
         self._lband_enable_gpio = Gpio("LBAND_ENABLE", mock_hw)
 
+        # si41xx synth info
+        self._relock_count = 0
+
         # beacon downlink: UDP client
         logger.info(f"Beacon socket: {self.BEACON_DOWNLINK_ADDR}")
         self._beacon_downlink_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -78,7 +81,8 @@ class RadiosService(Service):
             self.enable()
         if not self.is_si41xx_locked:
             logger.error("si41xx unlocked, resetting lband synth")
-            self.node.od["lband"]["synth_relock_count"].value += 1
+            self._relock_count += 1
+            self.node.od["lband"]["synth_relock_count"].value = self._relock_count.bit_length()
             self._si41xx.stop()
             self._si41xx.start()
         recv = self._recv_edl_request()
@@ -99,7 +103,8 @@ class RadiosService(Service):
         self._lband_enable_gpio.high()
         self.uhf_tot_clear()
         self._si41xx.start()
-        self.node.od["lband"]["synth_relock_count"].value += 1
+        self._relock_count += 1
+        self.node.od["lband"]["synth_relock_count"].value = self._relock_count.bit_length()
         if not self._mock_hw:
             self.node.daemons["uhf"].start()
             self.node.daemons["lband"].start()


### PR DESCRIPTION
This changes synth_relock_count to be log2 + 1 the number of resets. We mostly care that that relocking is happening none at all, a little bit, or a lot, and in the a lot case we don't want to overflow the value. log2 + 1 gives the vague range, and we'd be unlikely to see a value over ~15.

This also resets the value on boot.