### PR TITLE
Fix unbound error from bug #27

### DIFF
--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -69,7 +69,7 @@ class EdlCommandShell(Cmd):
             print(e)
             return tuple()
 
-		ret = None
+        ret = None
         if res_packet and res_packet.payload.values:
             ret = res_packet.payload.values
             print(f"Response {code.name}: {ret}")

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -69,6 +69,7 @@ class EdlCommandShell(Cmd):
             print(e)
             return tuple()
 
+		ret = None
         if res_packet and res_packet.payload.values:
             ret = res_packet.payload.values
             print(f"Response {code.name}: {ret}")


### PR DESCRIPTION
One-liner fix to fix unbound var error thrown in the `edl_cmd_shell` script.

See Issue #27 for details.