### PR TITLE
Create CacheStore, a merger of OreSatFileCache and a CFDP filestore

### DIFF
--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -20,6 +20,7 @@ from olaf import (
 )
 
 from . import C3State, __version__
+from .protocols.cachestore import CacheStore
 from .services.beacon import BeaconService
 from .services.edl import EdlService
 from .services.node_manager import NodeManagerService
@@ -119,6 +120,9 @@ def main():
     # start watchdog thread ASAP
     thread = Thread(target=watchdog, daemon=True)
     thread.start()
+
+    # The C3 needs a special OreSatFileCache that can speak CFDP
+    app.node._fwrite_cache = CacheStore(app.node.fwrite_cache.dir)  # pylint: disable=W0212
 
     app.od["versions"]["sw_version"].value = __version__
     if app.od["versions"]["hw_version"].value == "6.0":

--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -1,0 +1,141 @@
+"""Implements CacheStore, the merger of OreSatFileCache with a CFDP Filestore"""
+
+import os
+from bisect import insort_left
+from pathlib import Path
+from typing import BinaryIO, Optional
+
+from cfdppy.filestore import FilestoreResult, VirtualFilestore
+from olaf import OreSatFile, OreSatFileCache
+
+
+class CacheStore(VirtualFilestore, OreSatFileCache):
+    """Extends an OreSatFileCache with the CFDP filestore interface"""
+
+    # Paths are assumed to be given relative to the cache dir. Since there's no subdirectories
+    # allowed, it should always be a basename
+
+    def read_data(
+        self, file: Path, offset: Optional[int] = None, read_len: Optional[int] = None
+    ) -> bytes:
+        with self._lock:
+            for f in self._data:
+                if file.name == f.name:
+                    with open(self._dir + f.name, "rb") as rf:
+                        rf.seek(offset or 0)
+                        return rf.read(read_len)
+            raise FileNotFoundError(file)
+
+    def read_from_opened_file(self, bytes_io: BinaryIO, offset: int, read_len: int) -> bytes:
+        with self._lock:
+            bytes_io.seek(offset)
+            return bytes_io.read(read_len)
+
+    def is_directory(self, path: Path) -> bool:
+        # An oresat cache doesn't allow subdirectories
+        return False
+
+    def filename_from_full_path(self, path: Path) -> Optional[str]:
+        return path.name
+
+    def file_exists(self, path: Path) -> bool:
+        with self._lock:
+            return any(path.name == f.name for f in self._data)
+
+    def truncate_file(self, file: Path) -> None:
+        with self._lock:
+            for f in self._data:
+                if file.name == f.name:
+                    with open(self._dir + f.name, "w"):
+                        return
+            raise FileNotFoundError(file)
+
+    def write_data(self, file: Path, data: bytes, offset: Optional[int] = None) -> None:
+        with self._lock:
+            for f in self._data:
+                if file.name == f.name:
+                    with open(self._dir + f.name, "r+b") as wf:
+                        if offset is not None:
+                            wf.seek(offset)
+                        wf.write(data)
+                        return
+            raise FileNotFoundError(file)
+
+    def create_file(self, file: Path) -> FilestoreResult:
+        with self._lock:
+            new = Path(self._dir) / file.name
+            try:
+                osf = OreSatFile(new)
+            except ValueError:
+                return FilestoreResult.CREATE_NOT_ALLOWED
+
+            # Does the file already exist?
+            if any(file.name == f.name for f in self._data):
+                return FilestoreResult.CREATE_NOT_ALLOWED
+
+            new.touch()
+            insort_left(self._data, osf)
+            return FilestoreResult.CREATE_SUCCESS
+
+    def delete_file(self, file: Path) -> FilestoreResult:
+        # I would use OreSatFileCache.remove() here but it doesn't tell me if it failed
+        with self._lock:
+            for f in self._data:
+                if f.name == file.name:
+                    os.remove(self._dir + f.name)
+                    self._data.remove(f)
+                    return FilestoreResult.DELETE_SUCCESS
+            return FilestoreResult.DELETE_FILE_DOES_NOT_EXIST
+
+    def rename_file(self, old_file: Path, new_file: Path) -> FilestoreResult:
+        # old_file must exist in the cache but new_file can be any valid name
+        with self._lock:
+            for f in self._data:
+                if old_file.name == f.name:
+                    try:
+                        new = OreSatFile(new_file.name)
+                    except ValueError:
+                        return FilestoreResult.RENAME_NOT_PERFORMED
+                    self._data.remove(f)
+                    Path(self._dir, f.name).rename(self._dir + new.name)
+                    insort_left(self._data, new)
+                    return FilestoreResult.RENAME_SUCCESS
+            return FilestoreResult.RENAME_OLD_FILE_DOES_NOT_EXIST
+
+    def replace_file(self, replaced_file: Path, source_file: Path) -> FilestoreResult:
+        # both arguments must exist in the cache. replaced keeps its name but get's sources
+        # contents. source is removed.
+        with self._lock:
+            if not any(replaced_file.name == f.name for f in self._data):
+                return FilestoreResult.REPLACE_FILE_NAME_ONE_TO_BE_REPLACED_DOES_NOT_EXIST
+
+            for f in self._data:
+                if source_file.name == f.name:
+                    self._data.remove(f)
+                    Path(self._dir, source_file).replace(self._dir + replaced_file.name)
+                    return FilestoreResult.REPLACE_SUCCESS
+            return FilestoreResult.REPLACE_FILE_NAME_TWO_REPLACE_SOURCE_NOT_EXIST
+
+    def create_directory(self, _dir_name: Path) -> FilestoreResult:
+        # OreSatCache doesn't have subdirectoriess
+        return FilestoreResult.NOT_PERFORMED
+
+    def remove_directory(self, _dir_name: Path, recursive: bool) -> FilestoreResult:
+        # OreSatCache doesn't have subdirectoriess
+        return FilestoreResult.NOT_PERFORMED
+
+    def list_directory(
+        self, _dir_name: Path, file_name: Path, recursive: bool = False
+    ) -> FilestoreResult:
+        # dir_name is ignored, there are no directories to be considered
+        try:
+            listing = OreSatFile(file_name.name)
+        except ValueError:
+            return FilestoreResult.NOT_PERFORMED
+
+        with self._lock, open(self._dir + file_name.name, "w") as f:
+            insort_left(self._data, listing)
+            # Explicitly not reading from self._data here to help report invalid states
+            for line in os.walk(self._dir) if recursive else os.listdir(self._dir):
+                f.write(f"{line}\n")
+            return FilestoreResult.SUCCESS

--- a/tests/protocols/test_cachestore.py
+++ b/tests/protocols/test_cachestore.py
@@ -1,0 +1,240 @@
+"""Tests CacheStore"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from cfdppy.filestore import FilestoreResult
+
+from oresat_c3.protocols.cachestore import CacheStore
+
+
+class TestCacheStore(unittest.TestCase):
+    """Tests CacheStore"""
+
+    def setUp(self):
+        self.cachedir = TemporaryDirectory()
+        self.cache = CacheStore(self.cachedir.name)
+        self.exists = Path("c3_exists_123")
+        self.doesnt = Path("c3_doesntexist_124")
+        self.invalid = Path("invalid")
+        self.directory = Path(".")
+        self.assertTrue(self.directory.is_dir())
+        self.assertEqual(self.directory.name, "")
+
+        self.assertEqual(self.cache.create_file(self.exists), FilestoreResult.CREATE_SUCCESS)
+
+    def tearDown(self):
+        self.cachedir.cleanup()
+
+    def test_read_data(self):
+        """Test read_data()"""
+        with self.assertRaises(FileNotFoundError):
+            self.cache.read_data(self.doesnt)
+        with self.assertRaises(FileNotFoundError):
+            self.cache.read_data(self.invalid)
+        with self.assertRaises(FileNotFoundError):
+            self.cache.read_data(self.directory)
+
+        # Nothing's been written
+        self.assertEqual(self.cache.read_data(self.exists), b"")
+        data = b"This is a test string of bytes \x01\x02\x03"
+        with open(self.cache._dir / self.exists, "wb") as f:
+            f.write(data)
+        self.assertEqual(self.cache.read_data(self.exists), data)
+        self.assertEqual(self.cache.read_data(self.exists, offset=10), data[10:])
+        self.assertEqual(self.cache.read_data(self.exists, read_len=10), data[:10])
+        self.assertEqual(self.cache.read_data(self.exists, offset=10, read_len=10), data[10:20])
+
+    def test_read_from_opened_file(self):
+        """Test read_from_opened_file()"""
+        data = b"This is a test string of bytes \x01\x02\x03"
+        with open(self.cache._dir / self.exists, "wb") as f:
+            f.write(data)
+
+        with open(self.cache._dir / self.exists, "rb") as f:
+            self.assertEqual(
+                self.cache.read_from_opened_file(f, offset=0, read_len=len(data)), data
+            )
+
+    def test_is_directory(self):
+        """Test is_directory()"""
+        self.assertFalse(self.cache.is_directory(self.exists))
+        self.assertFalse(self.cache.is_directory(self.doesnt))
+        self.assertFalse(self.cache.is_directory(self.invalid))
+        # This one technically is a directory, but it doesn't exist in the cache, so false
+        self.assertFalse(self.cache.is_directory(self.directory))
+
+    def test_filename_from_full_path(self):
+        """Test filename_from_full_path()"""
+        self.assertEqual(self.cache.filename_from_full_path(self.exists), self.exists.name)
+        self.assertEqual(self.cache.filename_from_full_path(self.directory), "")
+
+    def test_file_exists(self):
+        """Test file_exists()"""
+        self.assertTrue(self.cache.file_exists(self.exists))
+        self.assertFalse(self.cache.file_exists(self.doesnt))
+        self.assertFalse(self.cache.file_exists(self.invalid))
+        self.assertFalse(self.cache.file_exists(self.directory))
+
+    def test_truncate_file(self):
+        """Test truncate_file()"""
+        with self.assertRaises(FileNotFoundError):
+            self.cache.truncate_file(self.doesnt)
+        with self.assertRaises(FileNotFoundError):
+            self.cache.truncate_file(self.invalid)
+        with self.assertRaises(FileNotFoundError):
+            self.cache.truncate_file(self.directory)
+
+        full_path = self.cache._dir / self.exists
+        self.assertEqual(full_path.stat().st_size, 0)
+        self.cache.truncate_file(self.exists)
+        self.assertEqual(full_path.stat().st_size, 0)
+
+        data = b"This is a test string of bytes \x01\x02\x03"
+        with open(full_path, "wb") as f:
+            f.write(data)
+        self.assertEqual(full_path.stat().st_size, len(data))
+        self.cache.truncate_file(self.exists)
+        self.assertEqual(full_path.stat().st_size, 0)
+
+    def test_write_data(self):
+        """Test write_data()"""
+        data = b"This is a test string of bytes \x01\x02\x03"
+        with self.assertRaises(FileNotFoundError):
+            self.cache.write_data(self.doesnt, data)
+        with self.assertRaises(FileNotFoundError):
+            self.cache.write_data(self.invalid, data)
+        with self.assertRaises(FileNotFoundError):
+            self.cache.write_data(self.directory, data)
+
+        full_path = self.cache._dir / self.exists
+
+        self.cache.write_data(self.exists, data)
+        with open(full_path, "rb") as f:
+            self.assertEqual(f.read(), data)
+
+        # writes don't truncate
+        self.cache.write_data(self.exists, b"a")
+        with open(full_path, "rb") as f:
+            self.assertEqual(f.read(), b"a" + data[1:])
+
+        self.cache.write_data(self.exists, b"a" * len(data), offset=len(data))
+        with open(full_path, "rb") as f:
+            self.assertEqual(f.read(), b"a" + data[1:] + b"a" * len(data))
+
+    def test_create_file(self):
+        """Test create_file()"""
+        self.assertEqual(self.cache.create_file(self.exists), FilestoreResult.CREATE_NOT_ALLOWED)
+        self.assertEqual(self.cache.create_file(self.doesnt), FilestoreResult.CREATE_SUCCESS)
+        self.assertEqual(self.cache.create_file(self.invalid), FilestoreResult.CREATE_NOT_ALLOWED)
+        self.assertEqual(self.cache.create_file(self.directory), FilestoreResult.CREATE_NOT_ALLOWED)
+
+        new = Path("c3_newfile_125")
+        self.assertEqual(self.cache.create_file(new), FilestoreResult.CREATE_SUCCESS)
+        self.assertTrue(self.cache.file_exists(new))
+        self.assertTrue(self.cache.file_exists(self.doesnt))
+        self.assertTrue((self.cache._dir / new).exists())
+        self.assertTrue((self.cache._dir / self.doesnt).exists())
+
+    def test_delete_file(self):
+        """Test delete_file()"""
+        self.assertEqual(self.cache.delete_file(self.exists), FilestoreResult.DELETE_SUCCESS)
+        self.assertEqual(
+            self.cache.delete_file(self.doesnt), FilestoreResult.DELETE_FILE_DOES_NOT_EXIST
+        )
+        self.assertEqual(
+            self.cache.delete_file(self.invalid), FilestoreResult.DELETE_FILE_DOES_NOT_EXIST
+        )
+        self.assertEqual(
+            self.cache.delete_file(self.directory), FilestoreResult.DELETE_FILE_DOES_NOT_EXIST
+        )
+
+        self.assertFalse(self.cache.file_exists(self.exists))
+        self.assertFalse((self.cache._dir / self.exists).exists())
+
+    def test_rename_file(self):
+        """Test rename_file()"""
+        self.assertEqual(
+            self.cache.rename_file(self.doesnt, self.exists),
+            FilestoreResult.RENAME_OLD_FILE_DOES_NOT_EXIST,
+        )
+        self.assertEqual(
+            self.cache.rename_file(self.exists, self.invalid), FilestoreResult.RENAME_NOT_PERFORMED
+        )
+        self.assertEqual(
+            self.cache.rename_file(self.exists, self.doesnt), FilestoreResult.RENAME_SUCCESS
+        )
+
+        self.assertTrue(self.cache.file_exists(self.doesnt))
+        self.assertFalse(self.cache.file_exists(self.exists))
+
+        self.assertTrue((self.cache._dir / self.doesnt).exists())
+        self.assertFalse((self.cache._dir / self.exists).exists())
+
+    def test_replace_file(self):
+        """Test replace_file()"""
+        self.assertEqual(
+            self.cache.replace_file(self.doesnt, self.exists),
+            FilestoreResult.REPLACE_FILE_NAME_ONE_TO_BE_REPLACED_DOES_NOT_EXIST,
+        )
+        self.assertEqual(
+            self.cache.replace_file(self.exists, self.invalid),
+            FilestoreResult.REPLACE_FILE_NAME_TWO_REPLACE_SOURCE_NOT_EXIST,
+        )
+        self.assertEqual(
+            self.cache.replace_file(self.exists, self.doesnt),
+            FilestoreResult.REPLACE_FILE_NAME_TWO_REPLACE_SOURCE_NOT_EXIST,
+        )
+
+        self.assertEqual(self.cache.create_file(self.doesnt), FilestoreResult.CREATE_SUCCESS)
+
+        self.assertEqual(
+            self.cache.replace_file(self.doesnt, self.exists), FilestoreResult.REPLACE_SUCCESS
+        )
+
+        self.assertTrue(self.cache.file_exists(self.doesnt))
+        self.assertFalse(self.cache.file_exists(self.exists))
+
+        self.assertTrue((self.cache._dir / self.doesnt).exists())
+        self.assertFalse((self.cache._dir / self.exists).exists())
+
+    def test_create_directory(self):
+        """Test create_directory()"""
+        self.assertEqual(
+            self.cache.create_directory(Path(self.cache._dir, "test")),
+            FilestoreResult.NOT_PERFORMED,
+        )
+
+    def test_remove_directory(self):
+        """Test remove_directory()"""
+        self.assertEqual(
+            self.cache.remove_directory(Path(self.cache._dir), recursive=True),
+            FilestoreResult.NOT_PERFORMED,
+        )
+        self.assertEqual(
+            self.cache.remove_directory(Path(self.cache._dir), recursive=False),
+            FilestoreResult.NOT_PERFORMED,
+        )
+
+    def test_list_directory(self):
+        """Test list_directory()"""
+        self.assertEqual(
+            self.cache.list_directory(Path(), self.invalid), FilestoreResult.NOT_PERFORMED
+        )
+
+        dirlist_111 = Path(self.cache._dir, "c3_dir_111.txt")
+        self.assertEqual(self.cache.list_directory(Path(), dirlist_111), FilestoreResult.SUCCESS)
+        self.assertTrue(self.cache.file_exists(dirlist_111))
+        with open(dirlist_111) as f:
+            self.assertCountEqual(f.read().split(), {self.exists.name, dirlist_111.name})
+
+        self.assertEqual(self.cache.create_file(self.doesnt), FilestoreResult.CREATE_SUCCESS)
+        dirlist_222 = Path(self.cache._dir, "c3_dir_222.txt")
+        self.assertEqual(self.cache.list_directory(Path(), dirlist_222), FilestoreResult.SUCCESS)
+        self.assertTrue(self.cache.file_exists(dirlist_222))
+        with open(dirlist_222) as f:
+            self.assertCountEqual(
+                f.read().split(),
+                {self.exists.name, dirlist_111.name, self.doesnt.name, dirlist_222.name},
+            )


### PR DESCRIPTION
The filestore specifically as implemented though cfdp-py, which has some "enhancements" to the base protocol spec. The defined API for an OreSatFileCache was insufficient to implement the filestore API, so I had build it on top of the internals. Special considerations:
- Locking with a non-reentrant lock meant the API generally couldn't be reused internally
- ._data needed to be kept up-to-date and in-order, this was aided by the bisect module
- There are no directories in an OreSatFileCache so they're ignored in paths provided, only taking the basename portions. Additionally directory operations are no-ops except for list_directory which lists all files in the cache directory (not just those known to the cache)
- All files should maintain the OreSatFile filename format.