### PR TITLE
Simple script to print received beacons

### DIFF
--- a/scripts/beacon.py
+++ b/scripts/beacon.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Listens for and prints C3 beacons"""
+
+
+import os
+import socket
+import sys
+from argparse import ArgumentParser
+from contextlib import suppress
+from zlib import crc32
+
+sys.path.insert(0, os.path.abspath(".."))
+
+from oresat_c3.protocols.ax25 import ax25_unpack
+
+
+def main():
+    parser = ArgumentParser("Receives and prints beacon packets")
+    parser.add_argument(
+        "-o", "--host", default="localhost", help="address to use, default is %(default)s"
+    )
+    parser.add_argument(
+        "-u",
+        "--beacon-port",
+        default=10015,
+        type=int,
+        help="port to receive beacons on, default is %(default)s",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="print out packet hex")
+    args = parser.parse_args()
+
+    host = args.host if args.host in ["localhost", "127.0.0.1"] else ""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind((host, args.beacon_port))
+
+    loop = 0
+    while True:
+        loop += 1
+        raw = s.recv(4096)
+        ax = ax25_unpack(raw)
+        print(f"{loop:4} | {ax.src_callsign}->{ax.dest_callsign}", end="")
+
+        crc = int.from_bytes(ax.payload[-4:], "little")
+        if crc != crc32(ax.payload[:-4]):
+            print(" | invalid CRC", end="")
+
+        if ax.payload[:3] != bytes("{{z", "ascii"):
+            print(" | invalid payload header", ax.payload[:3], end="")
+        print()
+
+        if args.verbose:
+            print(raw.hex())
+
+
+if __name__ == "__main__":
+    with suppress(KeyboardInterrupt):
+        main()

--- a/scripts/beacon.py
+++ b/scripts/beacon.py
@@ -33,6 +33,8 @@ def main():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind((host, args.beacon_port))
 
+    print("loop | source->dest  |   LBand EDL seq   rej  Batt V1       V2")
+
     loop = 0
     while True:
         loop += 1
@@ -43,13 +45,20 @@ def main():
         crc = int.from_bytes(ax.payload[-4:], "little")
         if crc != crc32(ax.payload[:-4]):
             print(" | invalid CRC", end="")
-
-        if ax.payload[:3] != bytes("{{z", "ascii"):
+        elif ax.payload[:3] != bytes("{{z", "ascii"):
             print(" | invalid payload header", ax.payload[:3], end="")
-        print()
-
+        else:
+            lband_rx = int.from_bytes(ax.payload[38:42], "little")
+            edl_seq = int.from_bytes(ax.payload[53:57], "little")
+            edl_rej = int.from_bytes(ax.payload[57:61], "little")
+            vbatt_1 = int.from_bytes(ax.payload[65:67], "little")
+            vbatt_2 = int.from_bytes(ax.payload[101:103], "little")
+            print(
+                f" | {lband_rx:4} rx {edl_seq:6}# {edl_rej:4}× {vbatt_1:6}mV {vbatt_2:6}mV", end=""
+            )
         if args.verbose:
-            print(raw.hex())
+            print("\n", raw.hex(), end="")
+        print()
 
 
 if __name__ == "__main__":

--- a/tests/protocols/test_ax25.py
+++ b/tests/protocols/test_ax25.py
@@ -2,11 +2,39 @@
 
 import unittest
 
-from oresat_c3.protocols.ax25 import AX25_PAYLOAD_MAX_LEN, Ax25Error, ax25_pack
+from oresat_c3.protocols.ax25 import AX25_PAYLOAD_MAX_LEN, Ax25, Ax25Error, ax25_pack, ax25_unpack
 
 
 class TestAx25(unittest.TestCase):
-    """Test ax25_pack."""
+    """Test ax25_pack and ax_25 unpack"""
+
+    def test_ax25_roundtrip(self):
+        """Test if unpack can recreate a packed packet"""
+        src = Ax25(
+            dest_callsign="DEST",
+            dest_ssid=1,
+            src_callsign="SRC",
+            src_ssid=1,
+            control=1,
+            pid=1,
+            command=True,
+            response=True,
+            payload=b"\x01\x02\x03",
+        )
+        result = ax25_unpack(
+            ax25_pack(
+                dest_callsign=src.dest_callsign,
+                dest_ssid=src.dest_ssid,
+                src_callsign=src.src_callsign,
+                src_ssid=src.src_ssid,
+                control=src.control,
+                pid=src.pid,
+                command=src.command,
+                response=src.response,
+                payload=src.payload,
+            )
+        )
+        self.assertEqual(src, result)
 
     def test_ax25_pack_invalid_dest_callsign_length(self):
         """Set destination callsign with a length greater than AX25_CALLSIGN_LEN"""


### PR DESCRIPTION
Mirroring the EDL scripts this script listens for beacons from the C3 and prints currently just the callsigns and if checksum failed. Other relevant fields could also be added but all the fields might be too much. Suggestions welcome for good fields to have.

We've wanted something like this in ground testing on flatclogs/ebv1 where either we didn't want to or couldn't run a full yamcs instance. This is also handy testing on a local machine for the same reasons.