### PR TITLE
Fix beacon payload offsets in script

### DIFF
--- a/scripts/beacon.py
+++ b/scripts/beacon.py
@@ -48,11 +48,11 @@ def main():
         elif ax.payload[:3] != bytes("{{z", "ascii"):
             print(" | invalid payload header", ax.payload[:3], end="")
         else:
-            lband_rx = int.from_bytes(ax.payload[38:42], "little")
-            edl_seq = int.from_bytes(ax.payload[53:57], "little")
-            edl_rej = int.from_bytes(ax.payload[57:61], "little")
-            vbatt_1 = int.from_bytes(ax.payload[65:67], "little")
-            vbatt_2 = int.from_bytes(ax.payload[101:103], "little")
+            lband_rx = int.from_bytes(ax.payload[22:26], "little")
+            edl_seq = int.from_bytes(ax.payload[37:41], "little")
+            edl_rej = int.from_bytes(ax.payload[41:45], "little")
+            vbatt_1 = int.from_bytes(ax.payload[49:51], "little")
+            vbatt_2 = int.from_bytes(ax.payload[81:83], "little")
             print(
                 f" | {lband_rx:4} rx {edl_seq:6}# {edl_rej:4}× {vbatt_1:6}mV {vbatt_2:6}mV", end=""
             )


### PR DESCRIPTION
It turns out that when all the test values are zero it's easy to confuse one zero with another. I had copied the offsets here from the readthedocs except there were two flaws:
- I copied them verbatim but those also include the header in the offsets whereas `ax.payload` does not. All the values need to have 16 subtracted from them.
- Due to a caching issue (see e6583f in oresat-configs) some values had the wrong larger type and so the offsets were off for all later entries.

Eventually there should be a beacon.pack()/.unpack() so I don't have to bother with manually setting offsets, but until then this suffices.