### PR TITLE
Replace OreSatId with Mission

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         path: resources/oresat-configs
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
 

--- a/oresat_c3/services/node_manager.py
+++ b/oresat_c3/services/node_manager.py
@@ -3,7 +3,7 @@ Node manager service.
 """
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import IntEnum
 from time import monotonic
 from typing import Union
@@ -108,7 +108,18 @@ class NodeManagerService(Service):
         self.opd_addr_to_name = {info.opd_address: name for name, info in cards.items()}
         self.node_id_to_name = {info.node_id: name for name, info in cards.items()}
 
-        self._data = {name: Node(**asdict(info)) for name, info in cards.items()}
+        self._data = {
+            name: Node(
+                name,
+                info.nice_name,
+                info.node_id,
+                info.processor,
+                info.opd_address,
+                info.opd_always_on,
+                info.child,
+            )
+            for name, info in cards.items()
+        }
         self._data["c3"].status = NodeState.ON
         self._loops = -1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ build
 cfdp-py==0.1.2
 dataclasses-json
 isort
-oresat-configs
-oresat-olaf>=3.4.0
+oresat-configs>=0.8.0
+oresat-olaf>=3.4.4
 pylama[all]
 pylama[toml]
 setuptools

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -10,7 +10,7 @@ from time import time
 from typing import Any, Union
 
 import canopen
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import Mission, OreSatConfig
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -29,7 +29,7 @@ class EdlCommandShell(Cmd):
     ):
         super().__init__()
 
-        self.configs = OreSatConfig(OreSatId.ORESAT0_5)
+        self.configs = OreSatConfig(Mission.default())
         self._hmac_key = hmac_key
         self._timeout = 5
         self._seq_num = seq_num

--- a/tests/protocols/test_edl_packet.py
+++ b/tests/protocols/test_edl_packet.py
@@ -53,7 +53,7 @@ class TestEdlPacket(unittest.TestCase):
 
         # Modifying FECF so that it is invalid
         edl_message_req = bytearray(edl_message_req)
-        edl_message_req = edl_message_req[:-2] + b"\xFF\xFF"
+        edl_message_req = edl_message_req[:-2] + b"\xff\xff"
         edl_message_req = bytes(edl_message_req)
 
         # Checking if EdlPacketError exception is raised for the invalid FECF

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -4,7 +4,7 @@ import unittest
 from time import time
 
 from olaf import CanNetwork, MasterNode, NodeStop
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import Mission, OreSatConfig
 
 from oresat_c3 import C3State
 from oresat_c3.services.state import StateService
@@ -14,7 +14,7 @@ class TestState(unittest.TestCase):
     """Test the C3 state service."""
 
     def setUp(self):
-        config = OreSatConfig(OreSatId.ORESAT0_5)
+        config = OreSatConfig(Mission.default())
         self.od = config.od_db["c3"]
         fram_def = config.fram_def
         network = CanNetwork("virtual", "vcan0")


### PR DESCRIPTION
As with the other similar changes, this uses Mission.default() for mission selection as OreSatId has been removed.

Also fixed up the CI a bit, stopped warnings for out-of-date actions.