### PR TITLE
Separate unpacking of raw frames from construction of EDL packets

### DIFF
--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -1,12 +1,16 @@
 """Implements CacheStore, the merger of OreSatFileCache with a CFDP Filestore"""
 
 import os
+import struct
 from bisect import insort_left
 from pathlib import Path
 from typing import BinaryIO, Optional
 
+import fastcrc.crc32
+from cfdppy.exceptions import ChecksumNotImplemented, SourceFileDoesNotExist
 from cfdppy.filestore import FilestoreResult, VirtualFilestore
 from olaf import OreSatFile, OreSatFileCache
+from spacepackets.cfdp import NULL_CHECKSUM_U32, ChecksumType
 
 
 class CacheStore(VirtualFilestore, OreSatFileCache):
@@ -25,6 +29,9 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                         rf.seek(offset or 0)
                         return rf.read(read_len)
             raise FileNotFoundError(file)
+
+    def file_size(self, file: Path) -> int:
+        return self.stat(file).st_size
 
     def read_from_opened_file(self, bytes_io: BinaryIO, offset: int, read_len: int) -> bytes:
         with self._lock:
@@ -153,3 +160,55 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
             for line in os.walk(self._dir) if recursive else os.listdir(self._dir):
                 f.write(f"{line}\n")
             return FilestoreResult.SUCCESS
+
+    def calc_modular_checksum(self, file_path: Path) -> bytes:
+        """Calculates the modular checksum of the file in file_path.
+
+        This was a module level function in cfdp-py, but it accessed the filesystem directly
+        instead of going through a filestore. It needs to access the filestore.
+        """
+        checksum = 0
+        offset = 0
+        while True:
+            data = self.read_data(file_path, offset, 4)
+            offset += 4
+            if not data:
+                break
+            checksum += int.from_bytes(data.ljust(4, b"\0"), byteorder="big", signed=False)
+
+        checksum %= 2**32
+        return struct.pack("!I", checksum)
+
+    def calculate_checksum(
+        self,
+        checksum_type: ChecksumType,
+        file_path: Path,
+        size_to_verify: int,
+        segment_len: int = 4096,
+    ) -> bytes:
+        if checksum_type == ChecksumType.NULL_CHECKSUM:
+            return NULL_CHECKSUM_U32
+        if not self.file_exists(file_path):
+            raise SourceFileDoesNotExist(file_path)
+        if checksum_type == ChecksumType.MODULAR:
+            return self.calc_modular_checksum(file_path)
+        if segment_len == 0:
+            raise ValueError("Segment length can not be 0")
+        if checksum_type == ChecksumType.CRC_32:
+            crc_func = fastcrc.crc32.iso_hdlc
+        elif checksum_type == ChecksumType.CRC_32C:
+            crc_func = fastcrc.crc32.iscsi
+        else:
+            raise ChecksumNotImplemented(checksum_type)
+        current = crc_func(b"")
+        current_offset = 0
+        # Calculate the file CRC
+        while current_offset < size_to_verify:
+            if current_offset + segment_len > size_to_verify:
+                read_len = size_to_verify - current_offset
+            else:
+                read_len = segment_len
+            if read_len > 0:
+                current = crc_func(self.read_data(file_path, current_offset, read_len), current)
+            current_offset += read_len
+        return struct.pack("!I", current)

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -3,14 +3,10 @@
 Most or all of these changes should eventually be submitted upstream.
 """
 
-import struct
-from pathlib import Path
-
 from cfdppy.exceptions import SourceFileDoesNotExist
-from cfdppy.handler.crc import CrcHelper
 from cfdppy.handler.dest import CompletionDisposition, DestHandler
 from cfdppy.handler.source import SourceHandler
-from spacepackets.cfdp import NULL_CHECKSUM_U32, ChecksumType, ConditionCode
+from spacepackets.cfdp import ConditionCode
 from spacepackets.cfdp.pdu import EofPdu, FileDataPdu
 from spacepackets.cfdp.pdu.file_data import FileDataParams
 
@@ -31,7 +27,7 @@ class VfsSourceHandler(SourceHandler):
             assert self._put_req.source_file is not None
             if not self.user.vfs.file_exists(self._put_req.source_file):
                 raise SourceFileDoesNotExist(self._put_req.source_file)
-            file_size = self.user.vfs.stat(self._put_req.source_file).st_size
+            file_size = self.user.vfs.file_size(self._put_req.source_file)
             if file_size == 0:
                 self._params.fp.metadata_only = True
             else:
@@ -49,56 +45,6 @@ class VfsSourceHandler(SourceHandler):
         fd_params = FileDataParams(file_data=file_data, offset=offset, segment_metadata=None)
         file_data_pdu = FileDataPdu(pdu_conf=self._params.pdu_conf, params=fd_params)
         self._add_packet_to_be_sent(file_data_pdu)
-
-
-class VfsCrcHelper(CrcHelper):
-    """CrcHelper but modified to only use Filestore operations.
-
-    It previously would attempt to open the paths passed to it directly instead of asking the
-    filestore, which failed when using the above PrefixFilestore.
-    """
-
-    def calc_modular_checksum(self, file_path: Path) -> bytes:
-        """Calculates the modular checksum of the file in file_path.
-
-        This was a module level function in cfdppy but it accessed the filesystem directly
-        instead of going through a filestore. It needs to become a CrcHelper method to use the
-        provided filestore.
-        """
-        checksum = 0
-        offset = 0
-        while True:
-            data = self.vfs.read_data(file_path, offset, 4)
-            offset += 4
-            if not data:
-                break
-            checksum += int.from_bytes(data.ljust(4, b"\0"), byteorder="big", signed=False)
-
-        checksum %= 2**32
-        return struct.pack("!I", checksum)
-
-    def calc_for_file(self, file_path: Path, file_sz: int, segment_len: int = 4096) -> bytes:
-        if self.checksum_type == ChecksumType.NULL_CHECKSUM:
-            return NULL_CHECKSUM_U32
-        if self.checksum_type == ChecksumType.MODULAR:
-            return self.calc_modular_checksum(file_path)
-        crc_obj = self.generate_crc_calculator()
-        if segment_len == 0:
-            raise ValueError("Segment length can not be 0")
-        if not self.vfs.file_exists(file_path):
-            raise SourceFileDoesNotExist(file_path)
-        current_offset = 0
-
-        # Calculate the file CRC
-        while current_offset < file_sz:
-            if current_offset + segment_len > file_sz:
-                read_len = file_sz - current_offset
-            else:
-                read_len = segment_len
-            if read_len > 0:
-                crc_obj.update(self.vfs.read_data(file_path, current_offset, read_len))
-            current_offset += read_len
-        return crc_obj.digest()
 
 
 class FixedDestHandler(DestHandler):

--- a/oresat_c3/protocols/edl_packet.py
+++ b/oresat_c3/protocols/edl_packet.py
@@ -138,7 +138,7 @@ class EdlPacket:
         return packet
 
     @classmethod
-    def unpack(cls, frame: TransferFrame, hmac_key: bytes, ignore_hmac: bool = False):
+    def from_frame(cls, frame: TransferFrame, hmac_key: bytes, ignore_hmac: bool = False):
         """
         Unpack the EDL packet.
 

--- a/oresat_c3/protocols/edl_packet.py
+++ b/oresat_c3/protocols/edl_packet.py
@@ -2,7 +2,6 @@
 Anything dealing with packing and unpacking EDL (Engineering Data Link) packets.
 """
 
-import binascii
 import hashlib
 import hmac
 from enum import IntEnum
@@ -10,14 +9,12 @@ from typing import Union
 
 from spacepackets.cfdp.pdu import PduFactory
 from spacepackets.cfdp.pdu.file_directive import AbstractPduBase
-from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLen  # type: ignore
 from spacepackets.uslp.frame import (  # type: ignore
     FrameType,
     TfdzConstructionRules,
     TransferFrame,
     TransferFrameDataField,
     UslpProtocolIdentifier,
-    VarFrameProperties,
 )
 from spacepackets.uslp.header import (  # type: ignore
     BypassSequenceControlFlag,
@@ -27,6 +24,7 @@ from spacepackets.uslp.header import (  # type: ignore
 )
 
 from .edl_command import EdlCommandCode, EdlCommandError, EdlCommandRequest, EdlCommandResponse
+from .uslp import HMAC_LEN, SEQ_NUM_LEN, SPACECRAFT_ID, TC_MIN_LEN
 
 SRC_DEST_ORESAT = SourceOrDestField.DEST
 SRC_DEST_UNICLOGS = SourceOrDestField.SOURCE
@@ -43,12 +41,6 @@ class EdlVcid(IntEnum):
     FILE_TRANSFER = 1
 
 
-def crc16_bytes(data: bytes) -> bytes:
-    """Helper function to generate the CRC16 of a message as bytes"""
-
-    return binascii.crc_hqx(data, 0).to_bytes(2, "little")
-
-
 def gen_hmac(hmac_key: bytes, message: bytes) -> bytes:
     """Helper function to generate HMAC value from HMAC key and the message."""
 
@@ -61,23 +53,6 @@ class EdlPacket:
 
     Only packs and unpacks the packet (does not process/run it).
     """
-
-    SPACECRAFT_ID = 0x4F53  # aka "OS" in ASCII
-
-    PRIMARY_HEADER_LEN = 7
-    SEQ_NUM_LEN = 4
-    DFH_LEN = 1
-    HMAC_LEN = 32
-    FECF_LEN = 2
-    TC_MIN_LEN = PRIMARY_HEADER_LEN + SEQ_NUM_LEN + DFH_LEN + HMAC_LEN + FECF_LEN
-
-    FRAME_PROPS = VarFrameProperties(
-        has_insert_zone=True,
-        has_fecf=True,
-        truncated_frame_len=0,
-        insert_zone_len=SEQ_NUM_LEN,
-        fecf_len=FECF_LEN,
-    )
 
     def __init__(
         self,
@@ -142,10 +117,10 @@ class EdlPacket:
         )
 
         # USLP transfer frame total length - 1
-        frame_len = len(payload_raw) + self.TC_MIN_LEN - 1
+        frame_len = len(payload_raw) + TC_MIN_LEN - 1
 
         frame_header = PrimaryHeader(
-            scid=self.SPACECRAFT_ID,
+            scid=SPACECRAFT_ID,
             map_id=0,
             vcid=self.vcid.value,
             src_dest=self.src_dest,
@@ -156,43 +131,29 @@ class EdlPacket:
             bypass_seq_ctrl_flag=BypassSequenceControlFlag.SEQ_CTRLD_QOS,
         )
 
-        seq_num_bytes = self.seq_num.to_bytes(self.SEQ_NUM_LEN, "little")
+        seq_num_bytes = self.seq_num.to_bytes(SEQ_NUM_LEN, "little")
         frame = TransferFrame(header=frame_header, tfdf=tfdf, insert_zone=seq_num_bytes)
         packet = frame.pack(frame_type=FrameType.VARIABLE)
-        packet += crc16_bytes(packet)
 
         return packet
 
     @classmethod
-    def unpack(cls, raw: bytes, hmac_key: bytes, ignore_hmac: bool = False):
+    def unpack(cls, frame: TransferFrame, hmac_key: bytes, ignore_hmac: bool = False):
         """
         Unpack the EDL packet.
 
         Parameters
         ----------
-        raw: bytes
-            The raw data to unpack.
+        frame : TransferFrame
+            The frame to unpack.
         hmac_key: bytes
             The hmac key.
         ignore_hmac: bool
             Ignore the HMAC value.
         """
 
-        if len(raw) < cls.TC_MIN_LEN:
-            raise EdlPacketError(f"EDL packet too short: {len(raw)}")
-
-        crc16_raw = raw[-cls.FECF_LEN :]
-        crc16_raw_calc = crc16_bytes(raw[: -cls.FECF_LEN])
-        if crc16_raw_calc != crc16_raw:
-            raise EdlPacketError(f"invalid FECF: {crc16_raw.hex()} vs {crc16_raw_calc.hex()}")
-
-        try:
-            frame = TransferFrame.unpack(raw, FrameType.VARIABLE, cls.FRAME_PROPS)
-        except UslpInvalidRawPacketOrFrameLen as e:
-            raise EdlPacketError("USLP invalid packet or frame length") from e
-
-        payload_raw = frame.tfdf.tfdz[: -cls.HMAC_LEN]
-        hmac_bytes = frame.tfdf.tfdz[-cls.HMAC_LEN :]
+        payload_raw = frame.tfdf.tfdz[:-HMAC_LEN]
+        hmac_bytes = frame.tfdf.tfdz[-HMAC_LEN:]
         hmac_bytes_calc = gen_hmac(hmac_key, payload_raw)
 
         if not ignore_hmac and hmac_bytes != hmac_bytes_calc:

--- a/oresat_c3/protocols/edl_packet.py
+++ b/oresat_c3/protocols/edl_packet.py
@@ -24,7 +24,7 @@ from spacepackets.uslp.header import (  # type: ignore
 )
 
 from .edl_command import EdlCommandCode, EdlCommandError, EdlCommandRequest, EdlCommandResponse
-from .uslp import HMAC_LEN, SEQ_NUM_LEN, SPACECRAFT_ID, TC_MIN_LEN
+from .uslp import HMAC_LEN, SEQ_NUM_LEN, make_frame
 
 SRC_DEST_ORESAT = SourceOrDestField.DEST
 SRC_DEST_UNICLOGS = SourceOrDestField.SOURCE
@@ -110,32 +110,14 @@ class EdlPacket:
 
         tfdz = payload_raw + gen_hmac(hmac_key, payload_raw)
 
-        tfdf = TransferFrameDataField(
-            tfdz_cnstr_rules=TfdzConstructionRules.VpNoSegmentation,
-            uslp_ident=UslpProtocolIdentifier.MISSION_SPECIFIC_INFO_1_MAPA_SDU,
-            tfdz=tfdz,
-        )
-
-        # USLP transfer frame total length - 1
-        frame_len = len(payload_raw) + TC_MIN_LEN - 1
-
-        frame_header = PrimaryHeader(
-            scid=SPACECRAFT_ID,
-            map_id=0,
+        seq_num_bytes = self.seq_num.to_bytes(SEQ_NUM_LEN, "little")
+        frame = make_frame(
+            payload=tfdz,
             vcid=self.vcid.value,
             src_dest=self.src_dest,
-            frame_len=frame_len,
-            vcf_count_len=0,
-            op_ctrl_flag=False,
-            prot_ctrl_cmd_flag=ProtocolCommandFlag.USER_DATA,
-            bypass_seq_ctrl_flag=BypassSequenceControlFlag.SEQ_CTRLD_QOS,
+            insert_zone=seq_num_bytes,
         )
-
-        seq_num_bytes = self.seq_num.to_bytes(SEQ_NUM_LEN, "little")
-        frame = TransferFrame(header=frame_header, tfdf=tfdf, insert_zone=seq_num_bytes)
-        packet = frame.pack(frame_type=FrameType.VARIABLE)
-
-        return packet
+        return frame.pack(frame_type=FrameType.VARIABLE)
 
     @classmethod
     def from_frame(cls, frame: TransferFrame, hmac_key: bytes, ignore_hmac: bool = False):

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -1,0 +1,68 @@
+from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+from spacepackets.uslp.frame import (
+    FrameType,
+    TransferFrame,
+    VarFrameProperties,
+)
+
+SPACECRAFT_ID = 0x4F53  # aka "OS" in ASCII
+
+PRIMARY_HEADER_LEN = 7
+SEQ_NUM_LEN = 4
+DFH_LEN = 1
+HMAC_LEN = 32
+FECF_LEN = 2
+TC_MIN_LEN = PRIMARY_HEADER_LEN + SEQ_NUM_LEN + DFH_LEN + HMAC_LEN + FECF_LEN
+
+FRAME_PROPS = VarFrameProperties(
+    has_insert_zone=True,
+    has_fecf=True,
+    truncated_frame_len=0,
+    insert_zone_len=SEQ_NUM_LEN,
+)
+
+
+class UslpInvalidSpacecraftIdError(Exception):
+    pass
+
+
+def unpack_frame(raw: bytes) -> TransferFrame:
+    """Unpack raw bytes into a valid TransferFrame
+
+    Parameters
+    ----------
+    raw: bytes
+        Raw bytes to unpack.
+
+    Returns
+    -------
+    TransferFrame
+        A valid TransferFrame.
+
+    Raises
+    ------
+    UslpInvalidRawPacketOrFrameLenError
+        If the packet is too short.
+    UslpInvalidSpacecraftIdError
+        The SCID of the packet does not match the spacecraft.
+    UslpCheckSumError
+        The FECF of the packet does not match the checksum.
+    UslpTruncatedFrameNotAllowed
+        Truncated frames are not allowed for variable frames.
+    """
+
+    # USLP Transfer Frame Validation
+    # a) Must have expected TFVN: checked by TransferFrame.unpack
+    # b) Must have expected MCID: checked below by also comparing SCID
+    # c) Header consistent with implemented features: covered by FRAME_PROPS + unpack
+    # d) Consistent number of octets: length check short-circuit with TC_MIN_LEN
+    #    Individual frame fields are check by unpack
+    # e) Computed CRC matches FECF: CRC is checked by unpack
+
+    if len(raw) < TC_MIN_LEN:
+        raise UslpInvalidRawPacketOrFrameLenError(f"Packet too short: {len(raw)}")
+    frame = TransferFrame.unpack(raw, FrameType.VARIABLE, FRAME_PROPS)
+    if frame.header.scid != SPACECRAFT_ID:
+        raise UslpInvalidSpacecraftIdError
+
+    return frame

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -1,7 +1,18 @@
+from typing import Optional
+
+from spacepackets.uslp import (
+    BypassSequenceControlFlag,
+    PrimaryHeader,
+    ProtocolCommandFlag,
+    SourceOrDestField,
+)
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
 from spacepackets.uslp.frame import (
     FrameType,
+    TfdzConstructionRules,
     TransferFrame,
+    TransferFrameDataField,
+    UslpProtocolIdentifier,
     VarFrameProperties,
 )
 
@@ -66,3 +77,67 @@ def unpack_frame(raw: bytes) -> TransferFrame:
         raise UslpInvalidSpacecraftIdError
 
     return frame
+
+
+def make_frame(
+    payload: bytes,
+    vcid: int,
+    src_dest: SourceOrDestField,
+    vcf_count: Optional[int] = None,
+    control_word: Optional[bytes] = None,
+    insert_zone: Optional[bytes] = None,
+) -> TransferFrame:
+    """Create and pack a USLP
+
+    Parameters
+    ----------
+    payload
+        The pre-packed payload.
+    vcid
+        The Virtual Channel Identifier of the frame.
+    src_dest
+        The Source or Destination identifier.
+    vcf_count
+        The Virtual Channel Frame count. If None, the VCF length is to 0 and no count is specified.
+    control_word
+        The CLCW, if any, to pack in the frame.
+    insert_zone
+        The insert zone data, if any.
+
+    Returns
+    -------
+    TransferFrame
+        The constructed Transfer Frame.
+    """
+
+    tfdf = TransferFrameDataField(
+        tfdz_cnstr_rules=TfdzConstructionRules.VpNoSegmentation,
+        uslp_ident=UslpProtocolIdentifier.USER_DEFINED_OCTET_STREAM,
+        tfdz=payload,
+    )
+
+    # USLP transfer frame total length - 1
+    frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
+    if insert_zone:
+        frame_len += len(insert_zone)
+
+    has_clcw = bool(control_word)
+    if has_clcw:
+        frame_len += len(control_word)
+
+    frame_header = PrimaryHeader(
+        scid=SPACECRAFT_ID,
+        map_id=0,
+        vcid=vcid,
+        src_dest=src_dest,
+        frame_len=frame_len,
+        vcf_count_len=bool(vcf_count),
+        vcf_count=vcf_count,
+        op_ctrl_flag=has_clcw,
+        prot_ctrl_cmd_flag=ProtocolCommandFlag.USER_DATA,
+        bypass_seq_ctrl_flag=BypassSequenceControlFlag.SEQ_CTRLD_QOS,
+    )
+
+    return TransferFrame(
+        header=frame_header, tfdf=tfdf, op_ctrl_field=control_word, insert_zone=insert_zone
+    )

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -9,19 +9,14 @@ from typing import Any, Optional
 
 import canopen
 from cfdppy import CfdpState, PacketDestination, get_packet_destination
-from cfdppy.exceptions import (
-    FsmNotCalledAfterPacketInsertion,
-    NoRemoteEntityCfgFound,
-    SourceFileDoesNotExist,
-    UnretrievedPdusToBeSent,
-)
+from cfdppy.exceptions import NoRemoteEntityConfigFound, SourceFileDoesNotExist
 from cfdppy.mib import (
     CheckTimerProvider,
     DefaultFaultHandlerBase,
-    IndicationCfg,
-    LocalEntityCfg,
-    RemoteEntityCfg,
-    RemoteEntityCfgTable,
+    IndicationConfig,
+    LocalEntityConfig,
+    RemoteEntityConfig,
+    RemoteEntityConfigTable,
 )
 from cfdppy.request import PutRequest
 from cfdppy.user import (
@@ -29,12 +24,11 @@ from cfdppy.user import (
     FileSegmentRecvdParams,
     MetadataRecvParams,
     TransactionFinishedParams,
-    TransactionId,
     TransactionParams,
 )
 from olaf import MasterNode, NodeStop, Service, logger
 from spacepackets.cfdp import ChecksumType, ConditionCode, FaultHandlerCode, TransmissionMode
-from spacepackets.cfdp.defs import DeliveryCode, FileStatus
+from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
 from spacepackets.cfdp.pdu import AbstractFileDirectiveBase
 from spacepackets.cfdp.tlv import (
     DirectoryListingResponse,
@@ -46,10 +40,14 @@ from spacepackets.cfdp.tlv import (
 )
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
+from spacepackets.uslp.defs import (
+    UslpChecksumError,
+    UslpInvalidRawPacketOrFrameLenError,
+)
 from spacepackets.util import ByteFieldU8
 
 from ..protocols.cachestore import CacheStore
-from ..protocols.cfdp import FixedDestHandler, VfsCrcHelper, VfsSourceHandler
+from ..protocols.cfdp import FixedDestHandler, VfsSourceHandler
 from ..protocols.edl_command import (
     EdlCommandCode,
     EdlCommandError,
@@ -57,6 +55,7 @@ from ..protocols.edl_command import (
     EdlCommandResponse,
 )
 from ..protocols.edl_packet import SRC_DEST_UNICLOGS, EdlPacket, EdlPacketError, EdlVcid
+from ..protocols.uslp import UslpInvalidSpacecraftIdError, unpack_frame
 from ..subsystems.rtc import set_rtc_time, set_system_time_to_rtc_time
 from .beacon import BeaconService
 from .node_manager import NodeManagerService
@@ -125,7 +124,17 @@ class EdlService(Service):
             return None
 
         try:
-            packet = EdlPacket.unpack(message, self._hmac_key, not self._flight_mode)
+            frame = unpack_frame(message)
+        except (
+            UslpInvalidSpacecraftIdError,
+            UslpInvalidRawPacketOrFrameLenError,
+            UslpChecksumError,
+        ) as e:
+            logger.error(e)
+            return None
+
+        try:
+            packet = EdlPacket.unpack(frame, self._hmac_key, not self._flight_mode)
         except EdlPacketError as e:
             self._rejected_count += 1
             self._rejected_count &= 0xFF_FF_FF_FF
@@ -408,15 +417,15 @@ class EdlFileReciever(CfdpUserBase):
             ConditionCode.POSITIVE_ACK_LIMIT_REACHED, FaultHandlerCode.ABANDON_TRANSACTION
         )
 
-        localcfg = LocalEntityCfg(
+        localcfg = LocalEntityConfig(
             local_entity_id=DEST_ID,
-            indication_cfg=IndicationCfg(),
+            indication_cfg=IndicationConfig(),
             default_fault_handlers=fault_handler,
         )
 
-        remote_entities = RemoteEntityCfgTable(
+        remote_entities = RemoteEntityConfigTable(
             [
-                RemoteEntityCfg(
+                RemoteEntityConfig(
                     entity_id=SOURCE_ID,
                     max_file_segment_len=None,
                     # FIXME this value should come from EdlPacket but EdlPacket does not define it.
@@ -437,7 +446,6 @@ class EdlFileReciever(CfdpUserBase):
             remote_cfg_table=remote_entities,
             check_timer_provider=DefaultCheckTimer(),
         )
-        self.dest._cksum_verif_helper = VfsCrcHelper(ChecksumType.NULL_CHECKSUM, self.vfs)
 
         self.source = VfsSourceHandler(
             cfg=localcfg,
@@ -446,7 +454,6 @@ class EdlFileReciever(CfdpUserBase):
             check_timer_provider=DefaultCheckTimer(),
             seq_num_provider=SeqCountProvider(16),
         )
-        self.source._crc_helper = VfsCrcHelper(ChecksumType.NULL_CHECKSUM, self.vfs)
 
         self.scheduled_requests: SimpleQueue[PutRequest] = SimpleQueue()
         self.active_requests: dict[TransactionId, TransactionId] = {}
@@ -475,23 +482,24 @@ class EdlFileReciever(CfdpUserBase):
         # Timers only expire when .state_machine() is called, and .state_machine() must
         # be called after all the packets have been drained, or after inserting a new
         # pdu.
+        tick_dest = True
+        tick_src = True
         if pdu:
             logger.info(f"<--- {pdu}")
 
             if get_packet_destination(pdu) == PacketDestination.DEST_HANDLER:
                 try:
-                    self.dest.insert_packet(pdu)
-                except Exception:
-                    # Usually this exception means the library is being used wrong, so we have
-                    # to be careful here. However there is a bug in the presence of dropped packets
-                    # where dest._params.last_inserted_packet does not get cleared.
-                    logger.exception("dest.state_machine() didn't properly clear inserted packet")
+                    self.dest.state_machine(pdu)
+                    tick_dest = False
+                except Exception as e:
+                    logger.exception(f"CFDP raised: {e}")
                     self.dest.reset()
             else:
                 try:
-                    self.source.insert_packet(pdu)
-                except Exception:
-                    logger.exception("source.state_machine() didn't properly clear inserted packet")
+                    self.source.state_machine(pdu)
+                    tick_src = False
+                except Exception as e:
+                    logger.exception(f"CFDP raised: {e}")
                     self.source.reset()
 
         if self.dest.state == CfdpState.IDLE and self.source.state == CfdpState.IDLE:
@@ -502,8 +510,8 @@ class EdlFileReciever(CfdpUserBase):
             else:
                 try:
                     self.source.put_request(request)
-                except (SourceFileDoesNotExist, NoRemoteEntityCfgFound):
-                    # Note that NoRemoteEntityCfgFound indicates that the MIB is missing info on
+                except (SourceFileDoesNotExist, NoRemoteEntityConfigFound):
+                    # Note that NoRemoteEntityConfigFound indicates that the MIB is missing info on
                     # the requested proxy transfer destination. CFDP doesn't seem to have a
                     # standard set of errors that cover this condition, and the least worst option
                     # resulted in an identical message to missing_file. Not super great, so if
@@ -511,13 +519,14 @@ class EdlFileReciever(CfdpUserBase):
                     self.scheduled_requests.put(self.missing_file_response(request))
 
         try:
-            self.dest.state_machine()
-            self.source.state_machine()
-        except Exception:
-            logger.exception("state_machine failed to update")
+            if tick_dest:
+                self.dest.state_machine()
+            if tick_src:
+                self.source.state_machine()
+        except Exception as e:
+            logger.exception(f"Failed to update state machine: {e}")
             self.dest.reset()
             self.source.reset()
-
         pdus = []
         while self.dest.packets_ready:
             pdus.append(self.dest.get_next_packet().pdu)

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -134,7 +134,7 @@ class EdlService(Service):
             return None
 
         try:
-            packet = EdlPacket.unpack(frame, self._hmac_key, not self._flight_mode)
+            packet = EdlPacket.from_frame(frame, self._hmac_key, not self._flight_mode)
         except EdlPacketError as e:
             self._rejected_count += 1
             self._rejected_count &= 0xFF_FF_FF_FF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,13 @@ classifiers = [
 ]
 dependencies = [
     "bitstring",
-    "cfdp-py==0.1.2",
+    "cfdp-py~=0.6.0",
     "dataclasses-json",
+    "fastcrc~=0.3",
     "oresat-configs==0.8.*",
     "oresat-olaf>=3.6.5",
     "smbus2",
-    "spacepackets",
+    "spacepackets>=0.30.1",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 bitstring
 black
 build
-cfdp-py==0.1.2
+cfdp-py~=0.6.0
 dataclasses-json
+fastcrc~=0.3
 isort
 oresat-configs==0.8.*
 oresat-olaf>=3.6.5
@@ -11,7 +12,7 @@ pylama[toml]
 setuptools
 setuptools-scm
 smbus2
-spacepackets
+spacepackets>=0.30.1
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-mermaid

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -12,6 +12,8 @@ from typing import Any, Union
 import canopen
 from oresat_configs import Mission, OreSatConfig
 
+from oresat_c3.protocols.uslp import unpack_frame
+
 sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EDL_COMMANDS, EdlCommandCode, EdlCommandRequest
@@ -63,7 +65,8 @@ class EdlCommandShell(Cmd):
                 # recv response
                 res_packet_raw = self._downlink_socket.recv(1024)
                 # parse respone
-                res_packet = EdlPacket.unpack(res_packet_raw, self._hmac_key)
+                frame = unpack_frame(res_packet_raw)
+                res_packet = EdlPacket.unpack(frame, self._hmac_key)
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718
             print(e)

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -66,7 +66,7 @@ class EdlCommandShell(Cmd):
                 res_packet_raw = self._downlink_socket.recv(1024)
                 # parse respone
                 frame = unpack_frame(res_packet_raw)
-                res_packet = EdlPacket.unpack(frame, self._hmac_key)
+                res_packet = EdlPacket.from_frame(frame, self._hmac_key)
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718
             print(e)

--- a/scripts/edl_file_upload.py
+++ b/scripts/edl_file_upload.py
@@ -18,16 +18,16 @@ from threading import Lock, Thread
 from typing import Any
 
 from cfdppy import CfdpState, PacketDestination, get_packet_destination
-from cfdppy.exceptions import NoRemoteEntityCfgFound
+from cfdppy.exceptions import NoRemoteEntityConfigFound
 from cfdppy.handler.dest import DestHandler
 from cfdppy.handler.source import SourceHandler
 from cfdppy.mib import (
     CheckTimerProvider,
     DefaultFaultHandlerBase,
-    IndicationCfg,
-    LocalEntityCfg,
-    RemoteEntityCfg,
-    RemoteEntityCfgTable,
+    IndicationConfig,
+    LocalEntityConfig,
+    RemoteEntityConfig,
+    RemoteEntityConfigTable,
 )
 from cfdppy.request import PutRequest
 from cfdppy.user import (
@@ -35,12 +35,11 @@ from cfdppy.user import (
     FileSegmentRecvdParams,
     MetadataRecvParams,
     TransactionFinishedParams,
-    TransactionId,
     TransactionParams,
 )
 from olaf import OreSatFile
 from spacepackets.cfdp import CfdpLv
-from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransmissionMode
+from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransactionId, TransmissionMode
 from spacepackets.cfdp.tlv import (
     DirectoryListingRequest,
     DirectoryParams,
@@ -52,6 +51,7 @@ from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
 
 from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket
+from oresat_c3.protocols.uslp import unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -168,7 +168,8 @@ class Downlink(Thread):
 
         while True:
             message = downlink.recv(4096)
-            packet = EdlPacket.unpack(message, self._hmac_key, True).payload
+            frame = unpack_frame(message)
+            packet = EdlPacket.unpack(frame, self._hmac_key, True).payload
             if self._bad_connection and not random.randrange(5):
                 print("X--- DROPPED", packet)
                 continue  # simulate dropped packets
@@ -213,11 +214,10 @@ class Source(Thread):
         while packet := self.downlink.get():
             with self.lock:
                 try:
-                    self.src.insert_packet(packet)
-                except NoRemoteEntityCfgFound as e:
+                    self.src.state_machine(packet)
+                except NoRemoteEntityConfigFound as e:
                     print(e)
                     traceback.print_exc()
-                self.src.state_machine()
                 while self.src.packets_ready:
                     pdu = self.src.get_next_packet().pdu
                     self.uplink.put(pdu)
@@ -264,10 +264,10 @@ class Dest(Thread):
         while True:
             try:
                 packet = self.downlink.get_nowait()
-                self.dest.insert_packet(packet)
             except Empty:
+                packet = None
                 time.sleep(0.1)
-            self.dest.state_machine()
+            self.dest.state_machine(packet)
             while self.dest.packets_ready:
                 pdu = self.dest.get_next_packet().pdu
                 self.uplink.put(pdu)
@@ -417,15 +417,15 @@ def main():
     SOURCE_ID = ByteFieldU8(0)
     DEST_ID = ByteFieldU8(1)
 
-    localcfg = LocalEntityCfg(
+    localcfg = LocalEntityConfig(
         local_entity_id=SOURCE_ID,
-        indication_cfg=IndicationCfg(),
+        indication_cfg=IndicationConfig(),
         default_fault_handlers=PrintFaults(),
     )
 
-    remote_entities = RemoteEntityCfgTable(
+    remote_entities = RemoteEntityConfigTable(
         [
-            RemoteEntityCfg(
+            RemoteEntityConfig(
                 entity_id=DEST_ID,
                 max_file_segment_len=None,
                 max_packet_len=args.buffer_size,

--- a/scripts/edl_file_upload.py
+++ b/scripts/edl_file_upload.py
@@ -169,7 +169,7 @@ class Downlink(Thread):
         while True:
             message = downlink.recv(4096)
             frame = unpack_frame(message)
-            packet = EdlPacket.unpack(frame, self._hmac_key, True).payload
+            packet = EdlPacket.from_frame(frame, self._hmac_key, True).payload
             if self._bad_connection and not random.randrange(5):
                 print("X--- DROPPED", packet)
                 continue  # simulate dropped packets

--- a/scripts/edl_ping_loop.py
+++ b/scripts/edl_ping_loop.py
@@ -117,7 +117,7 @@ class Link:
             self._downlink.settimeout(t)
             response = self._downlink.recv(4096)
             frame = unpack_frame(response)
-            payload = EdlPacket.unpack(frame, self.hmac).payload.values[0]
+            payload = EdlPacket.from_frame(frame, self.hmac).payload.values[0]
             t_recv = monotonic()
 
             # self.sent_times.keys() are monotonic (not to be confused with the timestamps from

--- a/scripts/edl_ping_loop.py
+++ b/scripts/edl_ping_loop.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest
 from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket
+from oresat_c3.protocols.uslp import unpack_frame
 
 
 class Timeout:
@@ -115,7 +116,8 @@ class Link:
         for t in timeout:
             self._downlink.settimeout(t)
             response = self._downlink.recv(4096)
-            payload = EdlPacket.unpack(response, self.hmac).payload.values[0]
+            frame = unpack_frame(response)
+            payload = EdlPacket.unpack(frame, self.hmac).payload.values[0]
             t_recv = monotonic()
 
             # self.sent_times.keys() are monotonic (not to be confused with the timestamps from

--- a/tests/protocols/test_edl_packet.py
+++ b/tests/protocols/test_edl_packet.py
@@ -28,13 +28,13 @@ class TestEdlPacket(unittest.TestCase):
         payload = EdlCommandRequest(EdlCommandCode.TX_CTRL, (True,))
         edl_packet_req = EdlPacket(payload, self.seq_num, SRC_DEST_ORESAT)
         edl_message_req = edl_packet_req.pack(self.hmac_key)
-        edl_packet_req2 = EdlPacket.unpack(unpack_frame(edl_message_req), self.hmac_key)
+        edl_packet_req2 = EdlPacket.from_frame(unpack_frame(edl_message_req), self.hmac_key)
         self.assertEqual(edl_packet_req, edl_packet_req2)
 
         payload = EdlCommandResponse(EdlCommandCode.TX_CTRL, (True,))
         edl_packet_res = EdlPacket(payload, self.seq_num, SRC_DEST_UNICLOGS)
         edl_message_res = edl_packet_res.pack(self.hmac_key)
-        edl_packet_res2 = EdlPacket.unpack(unpack_frame(edl_message_res), self.hmac_key)
+        edl_packet_res2 = EdlPacket.from_frame(unpack_frame(edl_message_res), self.hmac_key)
         self.assertEqual(edl_packet_res, edl_packet_res2)
 
     def test_unpack_short_packet(self):
@@ -46,7 +46,7 @@ class TestEdlPacket(unittest.TestCase):
         # Test if EdlPacketError "Packet too short" exception is thrown
         with self.assertRaises(UslpInvalidRawPacketOrFrameLenError):
             frame = unpack_frame(short_packet)
-            EdlPacket.unpack(frame, self.hmac_key)
+            EdlPacket.from_frame(frame, self.hmac_key)
 
     def test_unpack_invalid_fecf(self):
         """Test unpacking an EDL packet with an invalid FECF."""
@@ -63,7 +63,7 @@ class TestEdlPacket(unittest.TestCase):
         # Checking if UslpChecksumError exception is raised for the invalid FECF
         with self.assertRaises(UslpChecksumError):
             frame = unpack_frame(edl_message_req)
-            EdlPacket.unpack(frame, self.hmac_key)
+            EdlPacket.from_frame(frame, self.hmac_key)
 
     def test_unpack_invalid_hmac(self):
         """Test unpacking an EDL packet with an invalid HMAC."""
@@ -75,7 +75,7 @@ class TestEdlPacket(unittest.TestCase):
 
         frame = unpack_frame(edl_message_req)
         with self.assertRaises(EdlPacketError):
-            EdlPacket.unpack(frame, self.hmac_key)
+            EdlPacket.from_frame(frame, self.hmac_key)
 
     def test_unpack_invalid_vcid(self):
         "" "Test unpacking an EDL packet with an invalid VCID." ""
@@ -93,4 +93,4 @@ class TestEdlPacket(unittest.TestCase):
 
         frame = unpack_frame(req)
         with self.assertRaises(EdlPacketError):
-            EdlPacket.unpack(frame, self.hmac_key)
+            EdlPacket.from_frame(frame, self.hmac_key)

--- a/tests/protocols/test_edl_packet.py
+++ b/tests/protocols/test_edl_packet.py
@@ -3,6 +3,8 @@
 import unittest
 from enum import IntEnum
 
+from spacepackets.uslp.defs import UslpChecksumError, UslpInvalidRawPacketOrFrameLenError
+
 from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest, EdlCommandResponse
 from oresat_c3.protocols.edl_packet import (
     SRC_DEST_ORESAT,
@@ -10,6 +12,7 @@ from oresat_c3.protocols.edl_packet import (
     EdlPacket,
     EdlPacketError,
 )
+from oresat_c3.protocols.uslp import TC_MIN_LEN, unpack_frame
 
 
 class TestEdlPacket(unittest.TestCase):
@@ -25,24 +28,25 @@ class TestEdlPacket(unittest.TestCase):
         payload = EdlCommandRequest(EdlCommandCode.TX_CTRL, (True,))
         edl_packet_req = EdlPacket(payload, self.seq_num, SRC_DEST_ORESAT)
         edl_message_req = edl_packet_req.pack(self.hmac_key)
-        edl_packet_req2 = EdlPacket.unpack(edl_message_req, self.hmac_key)
+        edl_packet_req2 = EdlPacket.unpack(unpack_frame(edl_message_req), self.hmac_key)
         self.assertEqual(edl_packet_req, edl_packet_req2)
 
         payload = EdlCommandResponse(EdlCommandCode.TX_CTRL, (True,))
         edl_packet_res = EdlPacket(payload, self.seq_num, SRC_DEST_UNICLOGS)
         edl_message_res = edl_packet_res.pack(self.hmac_key)
-        edl_packet_res2 = EdlPacket.unpack(edl_message_res, self.hmac_key)
+        edl_packet_res2 = EdlPacket.unpack(unpack_frame(edl_message_res), self.hmac_key)
         self.assertEqual(edl_packet_res, edl_packet_res2)
 
     def test_unpack_short_packet(self):
         """Test unpacking an message that is to short to be a valid EDL packet."""
 
         # Preparing a packet that is shorter than the minimum length
-        short_packet = b"\x00" * (EdlPacket.TC_MIN_LEN - 1)
+        short_packet = b"\x00" * (TC_MIN_LEN - 1)
 
-        # Test if EdlPacketError "EDL packet too short" exception is thrown
-        with self.assertRaises(EdlPacketError):
-            EdlPacket.unpack(short_packet, self.hmac_key)
+        # Test if EdlPacketError "Packet too short" exception is thrown
+        with self.assertRaises(UslpInvalidRawPacketOrFrameLenError):
+            frame = unpack_frame(short_packet)
+            EdlPacket.unpack(frame, self.hmac_key)
 
     def test_unpack_invalid_fecf(self):
         """Test unpacking an EDL packet with an invalid FECF."""
@@ -56,23 +60,22 @@ class TestEdlPacket(unittest.TestCase):
         edl_message_req = edl_message_req[:-2] + b"\xff\xff"
         edl_message_req = bytes(edl_message_req)
 
-        # Checking if EdlPacketError exception is raised for the invalid FECF
-        with self.assertRaises(EdlPacketError):
-            EdlPacket.unpack(edl_message_req, self.hmac_key)
+        # Checking if UslpChecksumError exception is raised for the invalid FECF
+        with self.assertRaises(UslpChecksumError):
+            frame = unpack_frame(edl_message_req)
+            EdlPacket.unpack(frame, self.hmac_key)
 
     def test_unpack_invalid_hmac(self):
         """Test unpacking an EDL packet with an invalid HMAC."""
 
         payload = EdlCommandRequest(EdlCommandCode.TX_CTRL, (True,))
         edl_packet_req = EdlPacket(payload, self.seq_num, SRC_DEST_ORESAT)
-        edl_message_req = edl_packet_req.pack(self.hmac_key)
+        invalid_hmac = b"\0x12" * 32
+        edl_message_req = edl_packet_req.pack(invalid_hmac)
 
-        edl_message_req = bytearray(edl_message_req)
-        edl_message_req[-34:-2] = b"\0x12" * 32  # invalid hmac
-        edl_message_req = bytes(edl_message_req)
-
+        frame = unpack_frame(edl_message_req)
         with self.assertRaises(EdlPacketError):
-            EdlPacket.unpack(edl_message_req, self.hmac_key)
+            EdlPacket.unpack(frame, self.hmac_key)
 
     def test_unpack_invalid_vcid(self):
         "" "Test unpacking an EDL packet with an invalid VCID." ""
@@ -88,5 +91,6 @@ class TestEdlPacket(unittest.TestCase):
         edl_packet_req.vcid = TestEnum.INVALID
         req = edl_packet_req.pack(self.hmac_key)
 
+        frame = unpack_frame(req)
         with self.assertRaises(EdlPacketError):
-            EdlPacket.unpack(req, self.hmac_key)
+            EdlPacket.unpack(frame, self.hmac_key)


### PR DESCRIPTION
This PR splits USLP specific details into a new `uslp.py` file in the protocols module. For this PR it includes a function to unpack frames from raw bytes, and the same OreSat constants that were in the EDL packet definition. All USLP Transfer Frame Validations are covered, with most of them being delegated to the spacepackets library. Spacepackets is upgraded to include improvements to validation. cfdp-py was upgraded as well, since it has narrow version ranges for its spacepacket dependency.

cfdp-py has had many changes from the version it was on (spacepackets has fewer breakages). However, several bugs still don't seem to be fixed in upstream:

- `FixedDestHandler` is still required
- For PutRequest: `DestHandler does not respect closure_requested=None when trans_mode defaults to ACKNOWLEDGED`