### PR TITLE
Add virtual channel routing service

### DIFF
--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -134,9 +134,7 @@ def main():
     beacon_service = BeaconService(config.beacon_def, radios_service)
     node_mgr_service = NodeManagerService(config.cards, mock_hw=mock_hw)
     channel_router_service = ChannelRouterService(radios_service)
-    edl_service = EdlService(
-        app.node, radios_service, node_mgr_service, beacon_service, channel_router_service
-    )
+    edl_service = EdlService(app.node, node_mgr_service, beacon_service, channel_router_service)
 
     app.add_service(state_service)  # add state first to restore state from F-RAM
     app.add_service(radios_service)

--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -22,6 +22,7 @@ from olaf import (
 from . import C3State, __version__
 from .protocols.cachestore import CacheStore
 from .services.beacon import BeaconService
+from .services.channel_router import ChannelRouterService
 from .services.edl import EdlService
 from .services.node_manager import NodeManagerService
 from .services.radios import RadiosService
@@ -132,11 +133,15 @@ def main():
     radios_service = RadiosService(mock_hw)
     beacon_service = BeaconService(config.beacon_def, radios_service)
     node_mgr_service = NodeManagerService(config.cards, mock_hw=mock_hw)
-    edl_service = EdlService(app.node, radios_service, node_mgr_service, beacon_service)
+    channel_router_service = ChannelRouterService(radios_service)
+    edl_service = EdlService(
+        app.node, radios_service, node_mgr_service, beacon_service, channel_router_service
+    )
 
     app.add_service(state_service)  # add state first to restore state from F-RAM
     app.add_service(radios_service)
     app.add_service(beacon_service)
+    app.add_service(channel_router_service)
     app.add_service(edl_service)
     app.add_service(node_mgr_service)
 

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -1,0 +1,50 @@
+from queue import Empty, Full, Queue
+
+from olaf import Service, logger
+from spacepackets.uslp import TransferFrame
+
+from ..protocols.edl_packet import EdlVcid
+from ..protocols.uslp import unpack_frame
+from .radios import RadiosService
+
+
+class ChannelRouterService(Service):
+    """Virtual Channel Router Service
+
+    The router handles fetching raw data from the radios, unpacking frames, and finally places
+    valid frames into the appropriate queue.
+    """
+
+    QUEUE_SIZE = 256
+
+    def __init__(self, radios_service: RadiosService):
+        super().__init__()
+        self._radios_service = radios_service
+        self._routes: dict[EdlVcid, Queue[TransferFrame]] = {}
+
+    def on_loop(self) -> None:
+        try:
+            message = self._radios_service.recv_queue.get_nowait()
+        except Empty:
+            return
+
+        try:
+            frame = unpack_frame(message)
+            vcid = frame.header.vcid
+            if vcid in self._routes:
+                try:
+                    self._routes[vcid].put_nowait(frame)
+                except Full:
+                    logger.warning(f"{vcid} queue full: frame discarded")
+            else:
+                logger.error(f"No route for VCID {frame.header.vcid}")
+
+        except Exception as e:
+            logger.exception(f"Failed to unpack frame: {e}")
+
+    def request_route(self, vcid: EdlVcid) -> Queue[TransferFrame]:
+        if vcid in self._routes:
+            raise KeyError(f"Route already exists: {vcid}")
+        q: Queue[TransferFrame] = Queue(ChannelRouterService.QUEUE_SIZE)
+        self._routes[vcid] = q
+        return q

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -1,4 +1,4 @@
-from queue import Empty, Full, Queue, SimpleQueue
+from queue import Empty, SimpleQueue
 
 from olaf import Service, logger
 from spacepackets.uslp import TransferFrame
@@ -15,12 +15,10 @@ class ChannelRouterService(Service):
     valid frames into the appropriate queue.
     """
 
-    QUEUE_SIZE = 256
-
     def __init__(self, radios_service: RadiosService):
         super().__init__()
         self._radios_service = radios_service
-        self._uplink_routes: dict[EdlVcid, Queue[TransferFrame]] = {}
+        self._uplink_routes: dict[EdlVcid, SimpleQueue[TransferFrame]] = {}
         self._downlink_routes: dict[EdlVcid, SimpleQueue[TransferFrame]] = {}
 
     def on_loop(self) -> None:
@@ -40,17 +38,14 @@ class ChannelRouterService(Service):
             frame = unpack_frame(message)
             vcid = frame.header.vcid
             if vcid in self._uplink_routes:
-                try:
-                    self._uplink_routes[vcid].put_nowait(frame)
-                except Full:
-                    logger.warning(f"{vcid} queue full: frame discarded")
+                self._uplink_routes[vcid].put_nowait(frame)
             else:
                 logger.error(f"No route for VCID {frame.header.vcid}")
 
         except Exception as e:
             logger.exception(f"Failed to unpack frame: {e}")
 
-    def request_uplink_route(self, vcid: EdlVcid) -> Queue[TransferFrame]:
+    def request_uplink_route(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         """Request an uplink Virtual Channel route.
 
         Parameters
@@ -60,7 +55,7 @@ class ChannelRouterService(Service):
 
         Returns
         -------
-        Queue[TransferFrame]
+        SimpleQueue[TransferFrame]
             The queue from which received uplink frames for the VCID may be fetched.
 
         Raises
@@ -71,7 +66,7 @@ class ChannelRouterService(Service):
         if vcid in self._uplink_routes:
             raise KeyError(f"Uplink route for VCID={vcid} already exists")
         else:
-            q = Queue(ChannelRouterService.QUEUE_SIZE)
+            q = SimpleQueue()
             self._uplink_routes[vcid] = q
             return q
 

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -1,4 +1,4 @@
-from queue import Empty, Full, Queue
+from queue import Empty, Full, Queue, SimpleQueue
 
 from olaf import Service, logger
 from spacepackets.uslp import TransferFrame
@@ -20,9 +20,17 @@ class ChannelRouterService(Service):
     def __init__(self, radios_service: RadiosService):
         super().__init__()
         self._radios_service = radios_service
-        self._routes: dict[EdlVcid, Queue[TransferFrame]] = {}
+        self._uplink_routes: dict[EdlVcid, Queue[TransferFrame]] = {}
+        self._downlink_routes: dict[EdlVcid, SimpleQueue[TransferFrame]] = {}
 
     def on_loop(self) -> None:
+        for dl in self._downlink_routes.values():
+            try:
+                msg = dl.get_nowait()
+                self._radios_service.send_edl_response(msg)
+            except Empty:
+                continue
+
         try:
             message = self._radios_service.recv_queue.get_nowait()
         except Empty:
@@ -31,9 +39,9 @@ class ChannelRouterService(Service):
         try:
             frame = unpack_frame(message)
             vcid = frame.header.vcid
-            if vcid in self._routes:
+            if vcid in self._uplink_routes:
                 try:
-                    self._routes[vcid].put_nowait(frame)
+                    self._uplink_routes[vcid].put_nowait(frame)
                 except Full:
                     logger.warning(f"{vcid} queue full: frame discarded")
             else:
@@ -42,9 +50,19 @@ class ChannelRouterService(Service):
         except Exception as e:
             logger.exception(f"Failed to unpack frame: {e}")
 
-    def request_route(self, vcid: EdlVcid) -> Queue[TransferFrame]:
-        if vcid in self._routes:
-            raise KeyError(f"Route already exists: {vcid}")
-        q: Queue[TransferFrame] = Queue(ChannelRouterService.QUEUE_SIZE)
-        self._routes[vcid] = q
-        return q
+    def request_uplink_route(self, vcid: EdlVcid) -> Queue[TransferFrame]:
+        if vcid in self._uplink_routes:
+            return self._uplink_routes[vcid]
+        else:
+            q = Queue(ChannelRouterService.QUEUE_SIZE)
+            self._uplink_routes[vcid] = q
+            return q
+
+    def request_downlink_route(self, vcid: EdlVcid) -> SimpleQueue[bytes]:
+        if vcid in self._downlink_routes:
+            return self._downlink_routes[vcid]
+        else:
+            q = SimpleQueue()
+            self._downlink_routes[vcid] = q
+            logger.info(f"Created downlink route for VCID {vcid}")
+            return q

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -51,16 +51,51 @@ class ChannelRouterService(Service):
             logger.exception(f"Failed to unpack frame: {e}")
 
     def request_uplink_route(self, vcid: EdlVcid) -> Queue[TransferFrame]:
+        """Request an uplink Virtual Channel route.
+
+        Parameters
+        ----------
+        vcid
+            The VCID used to identify the route.
+
+        Returns
+        -------
+        Queue[TransferFrame]
+            The queue from which received uplink frames for the VCID may be fetched.
+
+        Raises
+        ------
+        KeyError
+            A route for `vcid` has already been claimed.
+        """
         if vcid in self._uplink_routes:
-            return self._uplink_routes[vcid]
+            raise KeyError(f"Uplink route for VCID={vcid} already exists")
         else:
             q = Queue(ChannelRouterService.QUEUE_SIZE)
             self._uplink_routes[vcid] = q
             return q
 
     def request_downlink_route(self, vcid: EdlVcid) -> SimpleQueue[bytes]:
+        """Request a downlink Virtual Channel route.
+
+        Parameters
+        ----------
+        vcid
+            The VCID used to identify the route.
+
+        Returns
+        -------
+        SimpleQueue[bytes]
+            A queue to place packed frames for downlinking.
+
+        Raises
+        ------
+        KeyError
+            A route for `vcid` has already been claimed.
+        """
+
         if vcid in self._downlink_routes:
-            return self._downlink_routes[vcid]
+            raise KeyError(f"Downlink route for VCID={vcid} already exists")
         else:
             q = SimpleQueue()
             self._downlink_routes[vcid] = q

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from pathlib import Path
 from queue import Empty, SimpleQueue
 from time import time
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import canopen
 from cfdppy import CfdpState, PacketDestination, get_packet_destination
@@ -26,7 +26,13 @@ from cfdppy.user import (
     TransactionParams,
 )
 from olaf import MasterNode, NodeStop, Service, logger
-from spacepackets.cfdp import ChecksumType, ConditionCode, FaultHandlerCode, TransmissionMode
+from spacepackets.cfdp import (
+    ChecksumType,
+    ConditionCode,
+    FaultHandlerCode,
+    PduHolder,
+    TransmissionMode,
+)
 from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
 from spacepackets.cfdp.pdu import AbstractFileDirectiveBase
 from spacepackets.cfdp.tlv import (
@@ -74,8 +80,18 @@ class EdlService(Service):
         self._radios_service = radios_service
         self._node_mgr_service = node_mgr_service
         self._beacon_service = beacon_service
-        self._cmd_route = channel_router_service.request_route(EdlVcid.C3_COMMAND)
-        self._file_route = channel_router_service.request_route(EdlVcid.FILE_TRANSFER)
+        self._cmd_downlink: SimpleQueue[bytes] = channel_router_service.request_downlink_route(
+            EdlVcid.C3_COMMAND
+        )
+        self._cmd_uplink: SimpleQueue[TransferFrame] = channel_router_service.request_uplink_route(
+            EdlVcid.C3_COMMAND
+        )
+        self._file_downlink: SimpleQueue[bytes] = channel_router_service.request_downlink_route(
+            EdlVcid.FILE_TRANSFER
+        )
+        self._file_uplink: SimpleQueue[TransferFrame] = channel_router_service.request_uplink_route(
+            EdlVcid.FILE_TRANSFER
+        )
 
         self._file_receiver = EdlFileReciever(node.fwrite_cache)
 
@@ -140,7 +156,7 @@ class EdlService(Service):
 
         return packet
 
-    def _respond(self, payload) -> None:
+    def _respond(self, vcid: EdlVcid, payload: Union[PduHolder, EdlCommandResponse]) -> None:
         try:
             res_packet = EdlPacket(payload, self._sequence_count, SRC_DEST_UNICLOGS)
             res_message = res_packet.pack(self._hmac_key)
@@ -148,11 +164,14 @@ class EdlService(Service):
             logger.exception(f"EDL response generation raised: {e}")
             return
 
-        self._radios_service.send_edl_response(res_message)
+        if vcid == EdlVcid.C3_COMMAND:
+            self._cmd_downlink.put_nowait(res_message)
+        elif vcid == EdlVcid.FILE_TRANSFER:
+            self._file_downlink.put_nowait(res_message)
 
     def _process_command(self) -> None:
         try:
-            frame = self._cmd_route.get_nowait()
+            frame = self._cmd_uplink.get_nowait()
         except Empty:
             return
         req_packet = self._frame_to_packet(frame)
@@ -163,13 +182,13 @@ class EdlService(Service):
                 res_payload = self._run_cmd(req_packet.payload)
                 if not res_payload.values:
                     return  # no response
-                self._respond(res_payload)
+                self._respond(EdlVcid.C3_COMMAND, res_payload)
             except Exception as e:  # pylint: disable=W0718
                 logger.error(f"EDL command {req_packet.payload.code.name} raised: {e}")
 
     def _process_cfdp(self) -> None:
         try:
-            frame = self._file_route.get_nowait()
+            frame = self._file_uplink.get_nowait()
         except Empty:
             return
         req_packet = self._frame_to_packet(frame)
@@ -188,7 +207,7 @@ class EdlService(Service):
             return
 
         for payload in res_payload:
-            self._respond(payload)
+            self._respond(EdlVcid.FILE_TRANSFER, payload)
 
     def on_loop(self):
         self._process_command()

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -61,7 +61,6 @@ from ..subsystems.rtc import set_rtc_time, set_system_time_to_rtc_time
 from .beacon import BeaconService
 from .channel_router import ChannelRouterService
 from .node_manager import NodeManagerService
-from .radios import RadiosService
 
 
 class EdlService(Service):
@@ -70,14 +69,12 @@ class EdlService(Service):
     def __init__(
         self,
         node: MasterNode,
-        radios_service: RadiosService,
         node_mgr_service: NodeManagerService,
         beacon_service: BeaconService,
         channel_router_service: ChannelRouterService,
     ):
         super().__init__()
 
-        self._radios_service = radios_service
         self._node_mgr_service = node_mgr_service
         self._beacon_service = beacon_service
         self._cmd_downlink: SimpleQueue[bytes] = channel_router_service.request_downlink_route(

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -1,6 +1,5 @@
 """'EDL Service"""
 
-from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
 from queue import Empty, SimpleQueue
@@ -40,10 +39,7 @@ from spacepackets.cfdp.tlv import (
 )
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
-from spacepackets.uslp.defs import (
-    UslpChecksumError,
-    UslpInvalidRawPacketOrFrameLenError,
-)
+from spacepackets.uslp import TransferFrame
 from spacepackets.util import ByteFieldU8
 
 from ..protocols.cachestore import CacheStore
@@ -55,9 +51,9 @@ from ..protocols.edl_command import (
     EdlCommandResponse,
 )
 from ..protocols.edl_packet import SRC_DEST_UNICLOGS, EdlPacket, EdlPacketError, EdlVcid
-from ..protocols.uslp import UslpInvalidSpacecraftIdError, unpack_frame
 from ..subsystems.rtc import set_rtc_time, set_system_time_to_rtc_time
 from .beacon import BeaconService
+from .channel_router import ChannelRouterService
 from .node_manager import NodeManagerService
 from .radios import RadiosService
 
@@ -71,12 +67,15 @@ class EdlService(Service):
         radios_service: RadiosService,
         node_mgr_service: NodeManagerService,
         beacon_service: BeaconService,
+        channel_router_service: ChannelRouterService,
     ):
         super().__init__()
 
         self._radios_service = radios_service
         self._node_mgr_service = node_mgr_service
         self._beacon_service = beacon_service
+        self._cmd_route = channel_router_service.request_route(EdlVcid.C3_COMMAND)
+        self._file_route = channel_router_service.request_route(EdlVcid.FILE_TRANSFER)
 
         self._file_receiver = EdlFileReciever(node.fwrite_cache)
 
@@ -117,22 +116,7 @@ class EdlService(Service):
     def _rejected_count(self, value):
         self._edl_rejected_count_obj.value = value
 
-    def _upack_last_recv(self) -> Optional[EdlPacket]:
-        try:
-            message = self._radios_service.recv_queue.get_nowait()
-        except Empty:
-            return None
-
-        try:
-            frame = unpack_frame(message)
-        except (
-            UslpInvalidSpacecraftIdError,
-            UslpInvalidRawPacketOrFrameLenError,
-            UslpChecksumError,
-        ) as e:
-            logger.error(e)
-            return None
-
+    def _frame_to_packet(self, frame: TransferFrame) -> Optional[EdlPacket]:
         try:
             packet = EdlPacket.from_frame(frame, self._hmac_key, not self._flight_mode)
         except EdlPacketError as e:
@@ -156,8 +140,39 @@ class EdlService(Service):
 
         return packet
 
-    def on_loop(self):
-        req_packet = self._upack_last_recv()
+    def _respond(self, payload) -> None:
+        try:
+            res_packet = EdlPacket(payload, self._sequence_count, SRC_DEST_UNICLOGS)
+            res_message = res_packet.pack(self._hmac_key)
+        except (EdlCommandError, EdlPacketError, ValueError) as e:
+            logger.exception(f"EDL response generation raised: {e}")
+            return
+
+        self._radios_service.send_edl_response(res_message)
+
+    def _process_command(self) -> None:
+        try:
+            frame = self._cmd_route.get_nowait()
+        except Empty:
+            return
+        req_packet = self._frame_to_packet(frame)
+        if req_packet is None:
+            self.sleep_ms(50)
+        else:
+            try:
+                res_payload = self._run_cmd(req_packet.payload)
+                if not res_payload.values:
+                    return  # no response
+                self._respond(res_payload)
+            except Exception as e:  # pylint: disable=W0718
+                logger.error(f"EDL command {req_packet.payload.code.name} raised: {e}")
+
+    def _process_cfdp(self) -> None:
+        try:
+            frame = self._file_route.get_nowait()
+        except Empty:
+            return
+        req_packet = self._frame_to_packet(frame)
 
         if req_packet is None:
             if self._file_receiver.state == CfdpState.BUSY:
@@ -165,35 +180,19 @@ class EdlService(Service):
             else:
                 self.sleep_ms(50)
                 return
-        elif req_packet.vcid == EdlVcid.C3_COMMAND:
-            try:
-                res_payload = self._run_cmd(req_packet.payload)
-                if not res_payload.values:
-                    return  # no response
-            except Exception as e:  # pylint: disable=W0718
-                logger.error(f"EDL command {req_packet.payload.code.name} raised: {e}")
-                return
-        elif req_packet.vcid == EdlVcid.FILE_TRANSFER:
-            res_payload = self._file_receiver.loop(req_packet.payload)
         else:
-            logger.error(f"got an EDL packet with unknown VCID: {req_packet.vcid}")
-            return
+            res_payload = self._file_receiver.loop(req_packet.payload)
 
         if res_payload is None:
             self.sleep_ms(50)
             return
 
-        if not isinstance(res_payload, Iterable):
-            res_payload = (res_payload,)
         for payload in res_payload:
-            try:
-                res_packet = EdlPacket(payload, self._sequence_count, SRC_DEST_UNICLOGS)
-                res_message = res_packet.pack(self._hmac_key)
-            except (EdlCommandError, EdlPacketError, ValueError) as e:
-                logger.exception(f"EDL response generation raised: {e}")
-                continue
+            self._respond(payload)
 
-            self._radios_service.send_edl_response(res_message)
+    def on_loop(self):
+        self._process_command()
+        self._process_cfdp()
 
     def _run_cmd(self, request: EdlCommandRequest) -> EdlCommandResponse:
         ret: Any = None


### PR DESCRIPTION
This adds a new service that sits between the EDL and the radios. The User (EDL) can request routes from the channel router using `ChannelRouterService.request_{downlink,uplink}_route(vcid)` to get or create a route to/from the radios on the given VCID. This PR introduces the router only to replace the existing logic, but eventually both optional routing to COP-1 services, USLP, and SDLS handling would happen in this service.