### PR TITLE
Power saving and a quick CI cleanup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,24 +23,32 @@ jobs:
         python-version: "3.9"
 
     - name: Install dependencies
+      id: dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
     # - name: Lint with Pylama
+    #  if: always() && steps.dependencies.conclusion == 'success'
     #  run: pylama
 
     - name: Check format with Black
+      if: always() && steps.dependencies.conclusion == 'success'
       run: black --check --diff .
 
     - name: Check format with isort
+      if: always() && steps.dependencies.conclusion == 'success'
       run: isort --check --diff .
 
     - name: Test with Python's unittest
+      if: always() && steps.dependencies.conclusion == 'success'
       run: python -m unittest
 
     - name: Test building pypi package
+      if: always() && steps.dependencies.conclusion == 'success'
       run: python -m build
 
     - name: Test building sphinx docs
-      run: make -C docs html
+      if: always() && steps.dependencies.conclusion == 'success'
+      # TZ=UTC fixes a crash when running sphinx inside nektos/act
+      run: TZ=UTC make -C docs html

--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -9,6 +9,7 @@ from queue import SimpleQueue
 
 from olaf import Gpio, Service, logger
 
+from .. import C3State
 from ..drivers.si41xx import Si41xx, Si41xxIfdiv
 
 
@@ -23,8 +24,8 @@ class RadiosService(Service):
 
     def __init__(self, mock_hw: bool = False):
         super().__init__()
-
         self._mock_hw = mock_hw
+        self.uhf = False
 
         self._si41xx = Si41xx(
             "LBAND_LO_nSEN",
@@ -75,10 +76,6 @@ class RadiosService(Service):
         self.enable()
 
     def on_loop(self):
-        if not self.is_uhf_tot_okay:
-            logger.error("tot okay was low, resetting radios")
-            self.disable()
-            self.enable()
         if not self.is_si41xx_locked:
             logger.error("si41xx unlocked, resetting lband synth")
             self._relock_count += 1
@@ -88,6 +85,8 @@ class RadiosService(Service):
         recv = self._recv_edl_request()
         if recv:
             self.recv_queue.put(recv)
+        if self.uhf and not self.node.od["status"].value == C3State.EDL:
+            self.uhf_off()
 
     def on_stop(self):
         self.disable()
@@ -98,15 +97,11 @@ class RadiosService(Service):
         logger.info("enabling radios")
         self._radio_enable_gpio.high()
         self.sleep_ms(100)
-        self._uhf_enable_gpio.high()
-        self.sleep_ms(100)
         self._lband_enable_gpio.high()
-        self.uhf_tot_clear()
         self._si41xx.start()
         self._relock_count += 1
         self.node.od["lband"]["synth_relock_count"].value = self._relock_count.bit_length()
         if not self._mock_hw:
-            self.node.daemons["uhf"].start()
             self.node.daemons["lband"].start()
 
     def disable(self):
@@ -114,12 +109,9 @@ class RadiosService(Service):
 
         logger.info("disabling radios")
         if not self._mock_hw:
-            self.node.daemons["uhf"].stop()
             self.node.daemons["lband"].stop()
         self._si41xx.stop()
         self._lband_enable_gpio.low()
-        self.sleep_ms(100)
-        self._uhf_enable_gpio.low()
         self.sleep_ms(100)
         self._radio_enable_gpio.low()
 
@@ -145,15 +137,30 @@ class RadiosService(Service):
         self.node.od["lband"]["synth_lock"].value = state
         return state
 
+    def uhf_on(self):
+        self.uhf = True
+        self._uhf_enable_gpio.high()
+        self.node.daemons["uhf"].start()
+        self.sleep_ms(200)
+        self.uhf_tot_clear()
+
+    def uhf_off(self):
+        self.sleep_ms(100)
+        self.node.daemons["uhf"].stop()
+        self._uhf_enable_gpio.low()
+        self.uhf = False
+
     def send_beacon(self, message: bytes):
         """Send a beacon."""
 
+        self.uhf_on()
         try:
             self._beacon_downlink_socket.sendto(message, self.BEACON_DOWNLINK_ADDR)
         except Exception as e:  # pylint: disable=W0718
             logger.error(f"failed to send beacon message: {e}")
 
         logger.debug(f'Sent beacon downlink packet: {message.hex(sep=" ")}')
+        self.uhf_off()
 
     def _recv_edl_request(self) -> bytes:
         """Recieve an EDL packet."""
@@ -170,6 +177,8 @@ class RadiosService(Service):
     def send_edl_response(self, message: bytes):
         """Send an EDL packet."""
 
+        if not self.uhf:
+            self.uhf_on()
         try:
             self._edl_downlink_socket.sendto(message, self.EDL_DOWNLINK_ADDR)
         except Exception as e:  # pylint: disable=W0718

--- a/oresat_c3/services/state.py
+++ b/oresat_c3/services/state.py
@@ -113,7 +113,6 @@ class StateService(Service):
 
         result = subprocess.run(
             ["systemctl", "stop", "oresat-c3-watchdog"],
-            shell=True,
             check=False,
             capture_output=True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,8 @@ name = "oresat-c3"
 description = "OreSat C3 OLAF app"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "GPL-3.0"}
+license = "GPL-3.0-or-later"
 classifiers = [
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -31,9 +30,6 @@ dynamic = ["version"]
 
 [project.scripts]
 oresat-c3 = "oresat_c3.__main__:main"
-
-[tool.setuptools.dynamic]
-version = {attr = "oresat_c3.__version__"}
 
 [tool.setuptools.packages.find]
 exclude = ["docs*", "tests*", "scripts*"]


### PR DESCRIPTION
The first patch was an old set of changes that should have been applied a while ago but I never got around to, it:
- Disables the downlink radio when not in use for power saving
- Fixes the 24hr watchdog timeout from not actually firing.

The second is touching up the github workflow to run the lints in parallel.