### PR TITLE
Add support for 'mcxn' processor type

### DIFF
--- a/oresat_c3/subsystems/opd.py
+++ b/oresat_c3/subsystems/opd.py
@@ -471,6 +471,7 @@ class Opd:
         opd_type = {
             "none": OpdNode,
             "stm32": OpdStm32Node,
+            "mcxn": OpdStm32Node,
             "octavo": OpdOctavoNode,
         }
 

--- a/oresat_c3/templates/node_manager.html
+++ b/oresat_c3/templates/node_manager.html
@@ -131,7 +131,7 @@
             let opt = document.createElement('option');
             opt.value = value;
             opt.innerHTML = key;
-            if (key == "BOOTLOADER" && status.processor != "stm32") {
+            if (key == "BOOTLOADER" && !(["stm32", "mcxn"].includes(status.processor))) {
               opt.style.display = "none";
             }
             select.appendChild(opt);


### PR DESCRIPTION
Oresat-configs introduced a new mcxn processor type which is the new embedded processor. For the moment the c3 will interact with it the same way as the stm32 nodes but this will eventually matter for interacting with the firmware bootloaders.

With this change then the C3 software should be ready for the new oresat1 configs.