### PR TITLE
Cfdp yamcs error fixes

### DIFF
--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -187,8 +187,12 @@ class EdlService(Service):
         try:
             frame = self._file_uplink.get_nowait()
         except Empty:
-            return
-        req_packet = self._frame_to_packet(frame)
+            frame = None
+
+        if frame is not None:
+            req_packet = self._frame_to_packet(frame)
+        else:
+            req_packet = None
 
         if req_packet is None:
             if self._file_receiver.state == CfdpState.BUSY:

--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -140,13 +140,15 @@ class RadiosService(Service):
     def uhf_on(self):
         self.uhf = True
         self._uhf_enable_gpio.high()
-        self.node.daemons["uhf"].start()
+        if "uhf" in self.node.daemons:
+            self.node.daemons["uhf"].start()
         self.sleep_ms(200)
         self.uhf_tot_clear()
 
     def uhf_off(self):
         self.sleep_ms(100)
-        self.node.daemons["uhf"].stop()
+        if "uhf" in self.node.daemons:
+            self.node.daemons["uhf"].stop()
         self._uhf_enable_gpio.low()
         self.uhf = False
 


### PR DESCRIPTION
Two updates needed for `Yamcs` to work on mock hardware with the `AT86RF215` daemon.

1. Empty return in `CFDP` was causing stalling in certain cases when sending data.
2. When running with mock hardware the `C3` does not create the daemon service. Causing a key error (`'uhf'`) when using the daemon.