### PR TITLE
fix: channel routing consumes too much CPU

### DIFF
--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -23,11 +23,12 @@ class ChannelRouterService(Service):
 
     def on_loop(self) -> None:
         for dl in self._downlink_routes.values():
-            try:
-                msg = dl.get_nowait()
-                self._radios_service.send_edl_response(msg)
-            except Empty:
-                continue
+            while True:
+                try:
+                    msg = dl.get_nowait()
+                    self._radios_service.send_edl_response(msg)
+                except Empty:
+                    break
 
         try:
             message = self._radios_service.recv_queue.get(timeout=0.1)

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -30,7 +30,7 @@ class ChannelRouterService(Service):
                 continue
 
         try:
-            message = self._radios_service.recv_queue.get_nowait()
+            message = self._radios_service.recv_queue.get(timeout=0.1)
         except Empty:
             return
 

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -172,9 +172,7 @@ class EdlService(Service):
         except Empty:
             return
         req_packet = self._frame_to_packet(frame)
-        if req_packet is None:
-            self.sleep_ms(50)
-        else:
+        if req_packet is not None:
             try:
                 res_payload = self._run_cmd(req_packet.payload)
                 if not res_payload.values:
@@ -194,13 +192,11 @@ class EdlService(Service):
             if self._file_receiver.state == CfdpState.BUSY:
                 res_payload = self._file_receiver.loop(None)
             else:
-                self.sleep_ms(50)
                 return
         else:
             res_payload = self._file_receiver.loop(req_packet.payload)
 
         if res_payload is None:
-            self.sleep_ms(50)
             return
 
         for payload in res_payload:
@@ -209,6 +205,7 @@ class EdlService(Service):
     def on_loop(self):
         self._process_command()
         self._process_cfdp()
+        self.sleep_ms(50)
 
     def _run_cmd(self, request: EdlCommandRequest) -> EdlCommandResponse:
         ret: Any = None


### PR DESCRIPTION
This is a quick fix for the increased channel CPU usage. Move EDL sleep to the main on_loop() and block with 0.1s timeout on getting from the radio in the channel router. This moves most of the CPU time back to the EDL with the 50ms sleep. CPU usage dropped by ~10% on my machine.

Fixes #69 