### PR TITLE
Allow use of COP-1 FARM-1 for uplink routes

### DIFF
--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -1,4 +1,5 @@
 """OreSat C3 app main."""
+
 import logging
 import os
 import socket
@@ -23,6 +24,7 @@ from . import C3State, __version__
 from .protocols.cachestore import CacheStore
 from .services.beacon import BeaconService
 from .services.channel_router import ChannelRouterService
+from .services.cop_manager import CopManagerService
 from .services.edl import EdlService
 from .services.node_manager import NodeManagerService
 from .services.radios import RadiosService
@@ -157,12 +159,14 @@ def main():
     radios_service = RadiosService(mock_hw)
     beacon_service = BeaconService(config.beacon_def, radios_service)
     node_mgr_service = NodeManagerService(config.cards, mock_hw=mock_hw)
-    channel_router_service = ChannelRouterService(radios_service)
+    cop_service = CopManagerService()
+    channel_router_service = ChannelRouterService(radios_service, cop_service)
     edl_service = EdlService(app.node, node_mgr_service, beacon_service, channel_router_service)
 
     app.add_service(state_service)  # add state first to restore state from F-RAM
     app.add_service(radios_service)
     app.add_service(beacon_service)
+    app.add_service(cop_service)
     app.add_service(channel_router_service)
     app.add_service(edl_service)
     app.add_service(node_mgr_service)

--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -136,7 +136,7 @@ def main():
     mock_args = [i.lower() for i in args.mock_hw]
     mock_hw = len(mock_args) != 0
 
-    cop1_logger = logging.getLogger("ccsds-cop.cop1")
+    cop1_logger = logging.getLogger("ccsds_cop")
     cop1_logger.handlers = [InterceptHandler()]
     if args.verbose:
         cop1_logger.setLevel(logging.DEBUG)

--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -1,5 +1,5 @@
 """OreSat C3 app main."""
-
+import logging
 import os
 import socket
 import time
@@ -28,6 +28,22 @@ from .services.node_manager import NodeManagerService
 from .services.radios import RadiosService
 from .services.state import StateService
 from .subsystems.rtc import set_system_time_to_rtc_time
+
+
+class InterceptHandler(logging.Handler):
+    def emit(self, record):
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find the correct call depth so loguru reports the right source location
+        frame, depth = logging.currentframe(), 0
+        while frame and (depth == 0 or frame.f_code.co_filename == logging.__file__):
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
 @rest_api.app.route("/beacon")
@@ -117,6 +133,14 @@ def main():
     args, config = olaf_setup("c3")
     mock_args = [i.lower() for i in args.mock_hw]
     mock_hw = len(mock_args) != 0
+
+    cop1_logger = logging.getLogger("ccsds-cop.cop1")
+    cop1_logger.handlers = [InterceptHandler()]
+    if args.verbose:
+        cop1_logger.setLevel(logging.DEBUG)
+    else:
+        cop1_logger.setLevel(logging.INFO)
+    cop1_logger.propagate = False
 
     # start watchdog thread ASAP
     thread = Thread(target=watchdog, daemon=True)

--- a/oresat_c3/protocols/edl_packet.py
+++ b/oresat_c3/protocols/edl_packet.py
@@ -39,6 +39,7 @@ class EdlVcid(IntEnum):
 
     C3_COMMAND = 0
     FILE_TRANSFER = 1
+    IDLE = 2
 
 
 def gen_hmac(hmac_key: bytes, message: bytes) -> bytes:

--- a/oresat_c3/protocols/edl_packet.py
+++ b/oresat_c3/protocols/edl_packet.py
@@ -60,6 +60,7 @@ class EdlPacket:
         payload: Union[EdlCommandRequest, EdlCommandResponse, AbstractPduBase],
         seq_num: int,
         src_dest: SourceOrDestField,
+        bypass: bool = False,
     ):
         """
         Parameters
@@ -70,6 +71,8 @@ class EdlPacket:
             The sequence number for packet.
         src_dest: SourceOrDestFiedld
             Origin of packet, use `SRC_DEST_ORESAT` or `SRC_DEST_UNICLOGS`.
+        bypass: bool
+            If True, send as a Type-BD (bypass) frame, skipping COP-1 sequence checking.
         """
 
         if isinstance(payload, (EdlCommandRequest, EdlCommandResponse)):
@@ -83,6 +86,7 @@ class EdlPacket:
         self.src_dest = src_dest
         self.seq_num = seq_num
         self.payload = payload
+        self.bypass = bypass
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, EdlPacket):
@@ -117,6 +121,7 @@ class EdlPacket:
             vcid=self.vcid.value,
             src_dest=self.src_dest,
             insert_zone=seq_num_bytes,
+            bypass=self.bypass,
         )
         return frame.pack(frame_type=FrameType.VARIABLE)
 

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -86,6 +86,7 @@ def make_frame(
     vcf_count: Optional[int] = None,
     control_word: Optional[bytes] = None,
     insert_zone: Optional[bytes] = None,
+    bypass: bool = False,
 ) -> TransferFrame:
     """Create and pack a USLP
 
@@ -103,6 +104,8 @@ def make_frame(
         The CLCW, if any, to pack in the frame.
     insert_zone
         The insert zone data, if any.
+    bypass
+        Specify if this frame is bypass (Type-BD) frame.
 
     Returns
     -------
@@ -121,7 +124,7 @@ def make_frame(
     if insert_zone:
         frame_len += len(insert_zone)
 
-    has_clcw = bool(control_word)
+    has_clcw = control_word is not None
     if has_clcw:
         frame_len += len(control_word)
 
@@ -135,7 +138,11 @@ def make_frame(
         vcf_count=vcf_count,
         op_ctrl_flag=has_clcw,
         prot_ctrl_cmd_flag=ProtocolCommandFlag.USER_DATA,
-        bypass_seq_ctrl_flag=BypassSequenceControlFlag.SEQ_CTRLD_QOS,
+        bypass_seq_ctrl_flag=(
+            BypassSequenceControlFlag.EXPEDITED_QOS
+            if bypass
+            else BypassSequenceControlFlag.SEQ_CTRLD_QOS
+        ),
     )
 
     return TransferFrame(

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -19,7 +19,7 @@ from spacepackets.uslp.frame import (
 SPACECRAFT_ID = 0x4F53  # aka "OS" in ASCII
 
 PRIMARY_HEADER_LEN = 7
-SEQ_NUM_LEN = 4
+SEQ_NUM_LEN = 6
 DFH_LEN = 1
 HMAC_LEN = 32
 FECF_LEN = 2

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -124,7 +124,7 @@ class ChannelRouterService(Service):
         if vcid in self._downlink_routes:
             raise KeyError(f"Downlink route for VCID={vcid} already exists")
         else:
-            q = SimpleQueue()
+            q: SimpleQueue[bytes] = SimpleQueue()
             self._downlink_routes[vcid] = q
             logger.info(f"Created downlink route for VCID {vcid}")
             return q

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -1,10 +1,18 @@
-from queue import Empty, SimpleQueue
+from __future__ import annotations
 
+from queue import Empty, SimpleQueue
+from time import monotonic
+
+from ccsds_cop.cop_1 import ControlWord, CopService
+from ccsds_cop.cop_1.farm import Farm1
 from olaf import Service, logger
 from spacepackets.uslp import TransferFrame
+from spacepackets.uslp.frame import FrameType
+from spacepackets.uslp.header import SourceOrDestField
 
 from ..protocols.edl_packet import EdlVcid
-from ..protocols.uslp import unpack_frame
+from ..protocols.uslp import SEQ_NUM_LEN, make_frame, unpack_frame
+from .cop_manager import CopManagerService
 from .radios import RadiosService
 
 
@@ -15,11 +23,15 @@ class ChannelRouterService(Service):
     valid frames into the appropriate queue.
     """
 
-    def __init__(self, radios_service: RadiosService):
+    _CLCW_INTERVAL = 1.0
+
+    def __init__(self, radios_service: RadiosService, cop_service: CopManagerService):
         super().__init__()
         self._radios_service = radios_service
+        self._cop_service = cop_service
         self._uplink_routes: dict[EdlVcid, SimpleQueue[TransferFrame]] = {}
-        self._downlink_routes: dict[EdlVcid, SimpleQueue[TransferFrame]] = {}
+        self._downlink_routes: dict[EdlVcid, SimpleQueue[bytes]] = {}
+        self._last_clcw_time = 0.0
 
     def on_loop(self) -> None:
         for dl in self._downlink_routes.values():
@@ -29,8 +41,21 @@ class ChannelRouterService(Service):
             except Empty:
                 continue
 
+        now = monotonic()
+        if now - self._last_clcw_time >= self._CLCW_INTERVAL:
+            for clcw in self._get_all_clcw():
+                frame = make_frame(
+                    payload=bytes(1),
+                    vcid=EdlVcid.IDLE,
+                    src_dest=SourceOrDestField.SOURCE,
+                    control_word=clcw.pack(),
+                    insert_zone=bytes(SEQ_NUM_LEN),
+                )
+                self._radios_service.send_edl_response(frame.pack(frame_type=FrameType.VARIABLE))
+            self._last_clcw_time = now
+
         try:
-            message = self._radios_service.recv_queue.get_nowait()
+            message = self._radios_service.recv_queue.get(timeout=0.1)
         except Empty:
             return
 
@@ -45,13 +70,17 @@ class ChannelRouterService(Service):
         except Exception as e:
             logger.exception(f"Failed to unpack frame: {e}")
 
-    def request_uplink_route(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
+    def request_uplink_route(
+        self, vcid: EdlVcid, use_cop: bool = False
+    ) -> SimpleQueue[TransferFrame]:
         """Request an uplink Virtual Channel route.
 
         Parameters
         ----------
         vcid
             The VCID used to identify the route.
+        use_cop
+            True enables COP-1 (FARM-1) on this route.
 
         Returns
         -------
@@ -65,10 +94,13 @@ class ChannelRouterService(Service):
         """
         if vcid in self._uplink_routes:
             raise KeyError(f"Uplink route for VCID={vcid} already exists")
+        if use_cop:
+            q = self._cop_service.create_farm_service(vcid)
+            self._uplink_routes[vcid] = self._cop_service.recv_queue
         else:
             q = SimpleQueue()
             self._uplink_routes[vcid] = q
-            return q
+        return q
 
     def request_downlink_route(self, vcid: EdlVcid) -> SimpleQueue[bytes]:
         """Request a downlink Virtual Channel route.
@@ -96,3 +128,20 @@ class ChannelRouterService(Service):
             self._downlink_routes[vcid] = q
             logger.info(f"Created downlink route for VCID {vcid}")
             return q
+
+    def _get_all_clcw(self) -> list[ControlWord]:
+        clcws = []
+        for v in self._uplink_routes.keys():
+            srv: CopService | None = self._cop_service.get_service(v)
+            if isinstance(srv, Farm1):
+                clcws.append(
+                    ControlWord(
+                        vcid=v,
+                        lockout=srv.lockout,
+                        wait=srv.wait,
+                        retransmit=srv.retransmit,
+                        farm_b_counter=srv.b_counter,
+                        report_value=srv.v_r,
+                    )
+                )
+        return clcws

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -28,6 +28,7 @@ class CopManagerService(Service):
     def on_loop(self) -> None:
         self._process_farm_higher()
         self._process_farm_lower()
+        self.sleep_ms(50)
 
     def _process_farm_lower(self) -> None:
         try:

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -1,0 +1,72 @@
+from queue import Empty, SimpleQueue
+from typing import Optional
+
+from ccsds_cop.cop_1 import CopService, Gvcid
+from ccsds_cop.cop_1.farm import (
+    Farm1,
+    FarmHigherServiceInterface,
+    FduArrivedIndication,
+    ValidFrameArrivedIndication,
+)
+from olaf import Service, logger
+from spacepackets.uslp import TransferFrame
+
+from ..protocols.edl_packet import EdlVcid
+
+
+class CopManagerService(Service):
+    """COP-1 Services Manager
+    This service acts as both the Higher and Lower procedures for any number of FARM-1
+    or FOP-1 COP-1 services
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._farms: dict[EdlVcid, tuple[CopService, SimpleQueue[TransferFrame]]] = {}
+        self.recv_queue: SimpleQueue[TransferFrame] = SimpleQueue()
+
+    def on_loop(self) -> None:
+        self._process_farm_higher()
+        self._process_farm_lower()
+
+    def _process_farm_lower(self) -> None:
+        try:
+            frame = self.recv_queue.get_nowait()
+            srv, q = self._farms.get(frame.header.vcid, (None, None))
+            print(srv)
+            if srv is not None:
+                if srv.lower_interface.buffer.appendleft(frame):
+                    srv.lower_interface.signal.appendleft(
+                        ValidFrameArrivedIndication(
+                            Gvcid(0b1100, frame.header.scid, frame.header.vcid)
+                        )
+                    )
+                    srv.tick()
+                else:
+                    logger.warning(f"FARM VCID={frame.header.vcid}: buffer full")
+        except Empty:
+            pass
+
+    def _process_farm_higher(self) -> None:
+        for srv, q in self._farms.values():
+            hi: FarmHigherServiceInterface = srv.higher_interface
+            try:
+                sig = hi.signal.pop()
+                if isinstance(sig, FduArrivedIndication):
+                    q.put_nowait(hi.buffer.pop())
+                    hi.buffer_release.set()
+            except IndexError:
+                continue
+
+    def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
+        logger.info(f"Creating FARM-1 Service for VCID {vcid}")
+        q: SimpleQueue[TransferFrame] = SimpleQueue()
+        self._farms[vcid] = (Farm1(w=20, vcf_count_length=2), q)
+        return q
+
+    def get_service(self, vcid: EdlVcid) -> Optional[CopService]:
+        entry = self._farms.get(vcid)
+        if entry is not None:
+            return entry[0]
+        else:
+            return entry

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -33,10 +33,9 @@ class CopManagerService(Service):
         try:
             frame = self.recv_queue.get_nowait()
             srv, q = self._farms.get(frame.header.vcid, (None, None))
-            print(srv)
             if srv is not None:
-                if srv.lower_interface.buffer.appendleft(frame):
-                    srv.lower_interface.signal.appendleft(
+                if srv.lower_interface.buffer.try_appendleft(frame):
+                    srv.lower_interface.signal.try_appendleft(
                         ValidFrameArrivedIndication(
                             Gvcid(0b1100, frame.header.scid, frame.header.vcid)
                         )

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -81,7 +81,8 @@ class EdlService(Service):
             EdlVcid.C3_COMMAND
         )
         self._cmd_uplink: SimpleQueue[TransferFrame] = channel_router_service.request_uplink_route(
-            EdlVcid.C3_COMMAND
+            EdlVcid.C3_COMMAND,
+            use_cop=True,
         )
         self._file_downlink: SimpleQueue[bytes] = channel_router_service.request_downlink_route(
             EdlVcid.FILE_TRANSFER

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "oresat-olaf>=3.6.5",
     "smbus2",
     "spacepackets>=0.30.1",
+    "ccsds-cop>=0.0.0",
 ]
 dynamic = ["version"]
 

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -12,12 +12,14 @@ from typing import Any, Union
 import canopen
 from oresat_configs import Mission, OreSatConfig
 
+from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+
 from oresat_c3.protocols.uslp import unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EDL_COMMANDS, EdlCommandCode, EdlCommandRequest
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
 
 
 class EdlCommandShell(Cmd):
@@ -54,7 +56,7 @@ class EdlCommandShell(Cmd):
         try:
             # make packet
             req = EdlCommandRequest(code, args)
-            req_packet = EdlPacket(req, self._seq_num, SRC_DEST_ORESAT)
+            req_packet = EdlPacket(req, self._seq_num, SRC_DEST_ORESAT, bypass=True)
             req_packet_raw = req_packet.pack(self._hmac_key)
 
             # send request
@@ -62,10 +64,16 @@ class EdlCommandShell(Cmd):
 
             edl_command = EDL_COMMANDS[code]
             if edl_command.res_fmt is not None or edl_command.res_unpack_func is not None:
-                # recv response
-                res_packet_raw = self._downlink_socket.recv(1024)
-                # parse respone
-                frame = unpack_frame(res_packet_raw)
+                for _ in range(10):
+                    res_packet_raw = self._downlink_socket.recv(1024)
+                    try:
+                        frame = unpack_frame(res_packet_raw)
+                    except UslpInvalidRawPacketOrFrameLenError:
+                        continue
+                    if frame.header.vcid == EdlVcid.C3_COMMAND:
+                        break
+                else:
+                    raise TimeoutError("No C3_COMMAND response received after 10 attempts")
                 res_packet = EdlPacket.from_frame(frame, self._hmac_key)
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -11,7 +11,6 @@ from typing import Any, Union
 
 import canopen
 from oresat_configs import Mission, OreSatConfig
-
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
 
 from oresat_c3.protocols.uslp import unpack_frame

--- a/scripts/edl_file_upload.py
+++ b/scripts/edl_file_upload.py
@@ -50,7 +50,9 @@ from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
 
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket
+from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
 from oresat_c3.protocols.uslp import unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
@@ -139,7 +141,7 @@ class Uplink(Thread):
                 print("---X DROPPED", payload)
                 continue  # simulate dropped packets
             print("--->", payload)
-            packet = EdlPacket(payload, self._sequence_number, SRC_DEST_ORESAT)
+            packet = EdlPacket(payload, self._sequence_number, SRC_DEST_ORESAT, bypass=True)
             message = packet.pack(self._hmac_key)
             uplink.send(message)
             print("Current sequence number:", self._sequence_number)
@@ -168,7 +170,12 @@ class Downlink(Thread):
 
         while True:
             message = downlink.recv(4096)
-            frame = unpack_frame(message)
+            try:
+                frame = unpack_frame(message)
+            except UslpInvalidRawPacketOrFrameLenError:
+                continue
+            if frame.header.vcid != EdlVcid.FILE_TRANSFER:
+                continue
             packet = EdlPacket.from_frame(frame, self._hmac_key, True).payload
             if self._bad_connection and not random.randrange(5):
                 print("X--- DROPPED", packet)

--- a/scripts/edl_file_upload.py
+++ b/scripts/edl_file_upload.py
@@ -48,9 +48,8 @@ from spacepackets.cfdp.tlv import (
 )
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
-from spacepackets.util import ByteFieldU8
-
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+from spacepackets.util import ByteFieldU8
 
 from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
 from oresat_c3.protocols.uslp import unpack_frame

--- a/scripts/edl_ping_loop.py
+++ b/scripts/edl_ping_loop.py
@@ -12,8 +12,10 @@ from typing import Generator, Union
 
 sys.path.insert(0, os.path.abspath(".."))
 
+from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+
 from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
 from oresat_c3.protocols.uslp import unpack_frame
 
 
@@ -79,7 +81,9 @@ class Link:
 
         self.sequence_number = self.sequence_number + 1 & 0xFFFF_FFFF
         request = EdlCommandRequest(EdlCommandCode.PING, (value,))
-        message = EdlPacket(request, self.sequence_number, SRC_DEST_ORESAT).pack(self.hmac)
+        message = EdlPacket(request, self.sequence_number, SRC_DEST_ORESAT, bypass=True).pack(
+            self.hmac
+        )
 
         self._uplink.send(message)
         self.sent_times[value] = monotonic()
@@ -116,7 +120,12 @@ class Link:
         for t in timeout:
             self._downlink.settimeout(t)
             response = self._downlink.recv(4096)
-            frame = unpack_frame(response)
+            try:
+                frame = unpack_frame(response)
+            except UslpInvalidRawPacketOrFrameLenError:
+                continue
+            if frame.header.vcid != EdlVcid.C3_COMMAND:
+                continue
             payload = EdlPacket.from_frame(frame, self.hmac).payload.values[0]
             t_recv = monotonic()
 


### PR DESCRIPTION
This adds the ability to specify uplink routes as COP routes (FARM-1) using the ccsds-cop implementation. This includes:

- Flag on uplink route request to use COP
- New CopManager service, which acts as the Higher and Lower Procedures (besides frame generation)
- Logging interceptor to add ccsds-cop logging to the C3's debug logging
- CLCWs sent on channel 2 (configured as IDLE frames) for every created FARM, every 1 second. This is well within the 3000ms YAMCS FOP-1 retransmission delay.
- C3 EDL scripts updated for COP-1. They do not yet contain a full FOP-1 sending end and instead send Type-BD bypass frames.
- Until SDLS is fully implemented the insert zone / SEQ_NUM_LEN value is increased to 6 bytes so the packets from YAMCS are properly recognized