### PR TITLE
Pull in olaf fixes for missing CAN networks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "gpiod",
     "fastcrc~=0.3",
     "oresat-configs>=1.1.2",
-    "oresat-olaf>=3.7.1",
+    "oresat-olaf>=3.7.2",
     "smbus2",
     "spacepackets>=0.30.1",
     "ccsds-cop>=0.0.0",


### PR DESCRIPTION
Just a routine increment that fixes crashes witnessed on live cards that were not connected to a full CAN Bus.