### PR TITLE
Add more node flasher options

### DIFF
--- a/oresat_c3/protocols/edl_command.py
+++ b/oresat_c3/protocols/edl_command.py
@@ -311,6 +311,10 @@ class EdlCommandCode(IntEnum):
         Delay between packets (default: 0.0).
     block_transfer: bool, optional
         True for block download, False for segmented (default: True).
+    request_crc: bool, optional
+        True to request a CRC check of the block download payload (default: False).
+    confirm_image: bool, optional
+        True to issue a command to confirm the zephyr image on next boot (default: False).
 
     Returns
     -------
@@ -350,16 +354,18 @@ def _edl_req_node_flash_pack_cb(values: tuple) -> bytes:
     filename = values[1]
     throttle_delay = values[2] if len(values) > 2 else 0.0
     block_transfer = values[3] if len(values) > 3 else True
-    req = struct.pack("<Bf?", node_id, throttle_delay, block_transfer)
+    request_crc = values[4] if len(values) > 4 else False
+    confirm_image = values[5] if len(values) > 5 else False
+    req = struct.pack("<Bf???", node_id, throttle_delay, block_transfer, request_crc, confirm_image)
     return req + filename.encode("utf-8")
 
 
 def _edl_req_node_flash_unpack_cb(raw: bytes) -> tuple:
-    fmt = "<Bf?"
+    fmt = "<Bf???"
     size = struct.calcsize(fmt)
-    node_id, throttle_delay, block_transfer = struct.unpack(fmt, raw[:size])
+    node_id, throttle_delay, block_transfer, request_crc, confirm_image = struct.unpack(fmt, raw[:size])
     filename = raw[size:].decode("utf-8").rstrip("\x00")
-    return (node_id, filename, throttle_delay, block_transfer)
+    return (node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image)
 
 
 EDL_COMMANDS = {

--- a/oresat_c3/protocols/edl_command.py
+++ b/oresat_c3/protocols/edl_command.py
@@ -312,7 +312,7 @@ class EdlCommandCode(IntEnum):
     block_transfer: bool, optional
         True for block download, False for segmented (default: True).
     request_crc: bool, optional
-        True to request a CRC check of the block download payload (default: False).
+        True to request a CRC check of the block download payload (default: True).
     confirm_image: bool, optional
         True to issue a command to confirm the zephyr image on next boot (default: False).
 
@@ -354,7 +354,7 @@ def _edl_req_node_flash_pack_cb(values: tuple) -> bytes:
     filename = values[1]
     throttle_delay = values[2] if len(values) > 2 else 0.0
     block_transfer = values[3] if len(values) > 3 else True
-    request_crc = values[4] if len(values) > 4 else False
+    request_crc = values[4] if len(values) > 4 else True
     confirm_image = values[5] if len(values) > 5 else False
     req = struct.pack("<Bf???", node_id, throttle_delay, block_transfer, request_crc, confirm_image)
     return req + filename.encode("utf-8")
@@ -363,7 +363,9 @@ def _edl_req_node_flash_pack_cb(values: tuple) -> bytes:
 def _edl_req_node_flash_unpack_cb(raw: bytes) -> tuple:
     fmt = "<Bf???"
     size = struct.calcsize(fmt)
-    node_id, throttle_delay, block_transfer, request_crc, confirm_image = struct.unpack(fmt, raw[:size])
+    node_id, throttle_delay, block_transfer, request_crc, confirm_image = struct.unpack(
+        fmt, raw[:size]
+    )
     filename = raw[size:].decode("utf-8").rstrip("\x00")
     return (node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image)
 

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -362,14 +362,15 @@ class EdlService(Service):
                 ecode = e.code
             ret = (node_id, index, subindex, ecode, len(data), data)
         elif request.code == EdlCommandCode.CO_NODE_FLASH:
-            node_id, filename, throttle_delay, block_transfer = request.args
+            node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image = request.args
             logger.info(
                 f"EDL queuing node flash for node 0x{node_id:02X} with file {filename} "
-                f"(throttle: {throttle_delay}, block: {block_transfer})"
+                f"(throttle: {throttle_delay}, block: {block_transfer}, crc: {request_crc}, confirm: {confirm_image})"
             )
             try:
                 self._node_flasher_service.enqueue_flash(
-                    node_id, filename, throttle_delay=throttle_delay, block_transfer=block_transfer
+                    node_id, filename, throttle_delay=throttle_delay, block_transfer=block_transfer,
+                    request_crc=request_crc, confirm_image=confirm_image
                 )
                 ret = True
             except Exception as e:

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -362,15 +362,22 @@ class EdlService(Service):
                 ecode = e.code
             ret = (node_id, index, subindex, ecode, len(data), data)
         elif request.code == EdlCommandCode.CO_NODE_FLASH:
-            node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image = request.args
+            node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image = (
+                request.args
+            )
             logger.info(
                 f"EDL queuing node flash for node 0x{node_id:02X} with file {filename} "
-                f"(throttle: {throttle_delay}, block: {block_transfer}, crc: {request_crc}, confirm: {confirm_image})"
+                f"(throttle: {throttle_delay}, block: {block_transfer}, "
+                f"crc: {request_crc}, confirm: {confirm_image})"
             )
             try:
                 self._node_flasher_service.enqueue_flash(
-                    node_id, filename, throttle_delay=throttle_delay, block_transfer=block_transfer,
-                    request_crc=request_crc, confirm_image=confirm_image
+                    node_id,
+                    filename,
+                    throttle_delay=throttle_delay,
+                    block_transfer=block_transfer,
+                    request_crc=request_crc,
+                    confirm_image=confirm_image,
                 )
                 ret = True
             except Exception as e:

--- a/oresat_c3/services/node_flasher.py
+++ b/oresat_c3/services/node_flasher.py
@@ -36,10 +36,11 @@ class NodeFlasherService(Service):
         cache_dir: str,
         node_mgr,
         throttle_delay: float = 0.0,
-        # request_crc defaults to False due to a possible CRC calculation mismatch in
-        # Zephyr's CANopenNode integration (depends on versioning). This is safe because
-        # MCUboot checks hash signatures of the firmware image before booting.
-        request_crc: bool = False,
+        # request_crc used to fail, possibly due to a CRC calculation mismatch
+        # between python-canopen and Zephyr's CANopenNode integration. If
+        # request_crc is false, the transfer still safe because MCUboot checks
+        # hash signatures of the firmware image before booting.
+        request_crc: bool = True,
         confirm_image: bool = False,
         sdo_timeout: float = 3.0,
         sdo_retries: int = 3,
@@ -98,9 +99,9 @@ class NodeFlasherService(Service):
         try:
             cmd = self.command_queue.get(timeout=QUEUE_GET_TIMEOUT)
             self._execute_flash(
-                cmd["node_id"], 
-                cmd["filename"], 
-                cmd["throttle_delay"], 
+                cmd["node_id"],
+                cmd["filename"],
+                cmd["throttle_delay"],
                 cmd["block_transfer"],
                 cmd["request_crc"],
                 cmd["confirm_image"],
@@ -119,10 +120,10 @@ class NodeFlasherService(Service):
         return status
 
     def _execute_flash(
-        self, 
-        node_id: int, 
-        filename: str, 
-        throttle_delay: float, 
+        self,
+        node_id: int,
+        filename: str,
+        throttle_delay: float,
         block_transfer: bool,
         request_crc: bool,
         confirm_image: bool,

--- a/oresat_c3/services/node_flasher.py
+++ b/oresat_c3/services/node_flasher.py
@@ -18,6 +18,7 @@ H1F57_FLASH_STATUS = 0x1F57
 PROGRAM_CTRL_STOP = 0x00
 PROGRAM_CTRL_START = 0x01
 PROGRAM_CTRL_CLEAR = 0x03
+PROGRAM_CTRL_ZEPHYR_CONFIRM = 0x80
 
 DEFAULT_STATUS_TIMEOUT = 30.0
 DEFAULT_BOOTUP_TIMEOUT = 20.0
@@ -39,6 +40,7 @@ class NodeFlasherService(Service):
         # Zephyr's CANopenNode integration (depends on versioning). This is safe because
         # MCUboot checks hash signatures of the firmware image before booting.
         request_crc: bool = False,
+        confirm_image: bool = False,
         sdo_timeout: float = 3.0,
         sdo_retries: int = 3,
     ):
@@ -53,6 +55,7 @@ class NodeFlasherService(Service):
         self.block_transfer = True
         self.throttle_delay = throttle_delay
         self.request_crc = request_crc
+        self.confirm_image = confirm_image
         self.sdo_timeout = sdo_timeout
         self.sdo_retries = sdo_retries
 
@@ -62,12 +65,18 @@ class NodeFlasherService(Service):
         filename: str,
         throttle_delay: Optional[float] = None,
         block_transfer: Optional[bool] = None,
+        request_crc: Optional[bool] = None,
+        confirm_image: Optional[bool] = None,
     ):
         """Called by EdlService to trigger a flash."""
         if throttle_delay is None:
             throttle_delay = self.throttle_delay
         if block_transfer is None:
             block_transfer = self.block_transfer
+        if request_crc is None:
+            request_crc = self.request_crc
+        if confirm_image is None:
+            confirm_image = self.confirm_image
 
         self.command_queue.put(
             {
@@ -75,18 +84,26 @@ class NodeFlasherService(Service):
                 "filename": filename,
                 "throttle_delay": throttle_delay,
                 "block_transfer": block_transfer,
+                "request_crc": request_crc,
+                "confirm_image": confirm_image,
             }
         )
         logger.info(
             f"Queued flash for Node 0x{node_id:02X} with file {filename} "
-            f"(throttle_delay={throttle_delay}, block_transfer={block_transfer})"
+            f"(throttle_delay={throttle_delay}, block_transfer={block_transfer}, "
+            f"request_crc={request_crc}, confirm_image={confirm_image})"
         )
 
     def on_loop(self):
         try:
             cmd = self.command_queue.get(timeout=QUEUE_GET_TIMEOUT)
             self._execute_flash(
-                cmd["node_id"], cmd["filename"], cmd["throttle_delay"], cmd["block_transfer"]
+                cmd["node_id"], 
+                cmd["filename"], 
+                cmd["throttle_delay"], 
+                cmd["block_transfer"],
+                cmd["request_crc"],
+                cmd["confirm_image"],
             )
         except Empty:
             pass
@@ -102,7 +119,13 @@ class NodeFlasherService(Service):
         return status
 
     def _execute_flash(
-        self, node_id: int, filename: str, throttle_delay: float, block_transfer: bool
+        self, 
+        node_id: int, 
+        filename: str, 
+        throttle_delay: float, 
+        block_transfer: bool,
+        request_crc: bool,
+        confirm_image: bool,
     ):
         filepath = os.path.join(self.cache_dir, filename)
 
@@ -169,7 +192,7 @@ class NodeFlasherService(Service):
                     buffering=self.download_buffer_size,
                     size=file_size,
                     block_transfer=block_transfer,
-                    request_crc_support=self.request_crc,
+                    request_crc_support=request_crc,
                 )
                 outfile.write(infile.read())
                 outfile.close()
@@ -182,6 +205,14 @@ class NodeFlasherService(Service):
             ctrl_sdo.raw = PROGRAM_CTRL_START
             target_node.nmt.wait_for_bootup(timeout=self.bootup_timeout)
             logger.info(f"Node {node_name} (0x{node_id:02X}) flashed and rebooted successfully.")
+
+            # Confirm the image if requested
+            if confirm_image:
+                logger.info(f"Confirming Zephyr image for node {node_name} (0x{node_id:02X})...")
+                target_node.nmt.state = "PRE-OPERATIONAL"
+                time.sleep(NMT_STATE_CHANGE_DELAY)
+                ctrl_sdo.raw = PROGRAM_CTRL_ZEPHYR_CONFIRM
+                logger.info("Zephyr image confirmed.")
 
         except Exception as e:
             logger.error(f"Node flasher failed during execution: {e}")

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -436,13 +436,21 @@ class EdlCommandShell(Cmd):
 
     def help_node_flash(self):
         """Print help message for node_flash command."""
-        print("node_flash <node> <filename> [throttle_delay] [block_transfer] [request_crc] [confirm_image]")
+        print(
+            "node_flash <node> <filename>"
+            "[throttle_delay] [block_transfer] [request_crc] [confirm_image]"
+        )
         print("  <node> is the node id (e.g. 0x7C or 42) or node name")
         print("  <filename> is the name of the bin file in the C3 cache to flash")
         print("  [throttle_delay] is an optional delay between packets in seconds (default: 0.0)")
         print("  [block_transfer] is optional (true/false, 1/0) for block download (default: true)")
-        print("  [request_crc] is optional (true/false, 1/0) to request a CRC check (default: false)")
-        print("  [confirm_image] is optional (true/false, 1/0) to confirm the image on boot (default: false)")
+        print(
+            "  [request_crc] is optional (true/false, 1/0) to request a CRC check (default: true)"
+        )
+        print(
+            "  [confirm_image] is optional (true/false, 1/0) to confirm the image on boot "
+            "(default: false)"
+        )
 
     def do_node_flash(self, arg: str):
         """Do the node_flash command."""
@@ -488,7 +496,7 @@ class EdlCommandShell(Cmd):
             else:
                 print("invalid block_transfer arg. Must be true/false or 1/0.")
                 return
-                
+
         if len(args) >= 5:
             arg4 = args[4].lower()
             if arg4 in ["true", "1", "t", "y", "yes"]:
@@ -498,7 +506,7 @@ class EdlCommandShell(Cmd):
             else:
                 print("invalid request_crc arg. Must be true/false or 1/0.")
                 return
-                
+
         if len(args) >= 6:
             arg5 = args[5].lower()
             if arg5 in ["true", "1", "t", "y", "yes"]:
@@ -510,7 +518,8 @@ class EdlCommandShell(Cmd):
                 return
 
         response = self._send_packet(
-            EdlCommandCode.CO_NODE_FLASH, (node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image)
+            EdlCommandCode.CO_NODE_FLASH,
+            (node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image),
         )
         if response is not None:
             print(f"Flash command sent. Response: {response}")

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -436,17 +436,19 @@ class EdlCommandShell(Cmd):
 
     def help_node_flash(self):
         """Print help message for node_flash command."""
-        print("node_flash <node> <filename> [throttle_delay] [block_transfer]")
+        print("node_flash <node> <filename> [throttle_delay] [block_transfer] [request_crc] [confirm_image]")
         print("  <node> is the node id (e.g. 0x7C or 42) or node name")
         print("  <filename> is the name of the bin file in the C3 cache to flash")
         print("  [throttle_delay] is an optional delay between packets in seconds (default: 0.0)")
         print("  [block_transfer] is optional (true/false, 1/0) for block download (default: true)")
+        print("  [request_crc] is optional (true/false, 1/0) to request a CRC check (default: false)")
+        print("  [confirm_image] is optional (true/false, 1/0) to confirm the image on boot (default: false)")
 
     def do_node_flash(self, arg: str):
         """Do the node_flash command."""
 
         args = arg.split()
-        if len(args) < 2 or len(args) > 4:
+        if len(args) < 2 or len(args) > 6:
             self.help_node_flash()
             return
 
@@ -467,6 +469,8 @@ class EdlCommandShell(Cmd):
 
         throttle_delay = 0.0
         block_transfer = True
+        request_crc = False
+        confirm_image = False
 
         if len(args) >= 3:
             try:
@@ -477,16 +481,36 @@ class EdlCommandShell(Cmd):
 
         if len(args) >= 4:
             arg3 = args[3].lower()
-            if arg3 in ["true", "1"]:
+            if arg3 in ["true", "1", "t", "y", "yes"]:
                 block_transfer = True
-            elif arg3 in ["false", "0"]:
+            elif arg3 in ["false", "0", "f", "n", "no"]:
                 block_transfer = False
             else:
                 print("invalid block_transfer arg. Must be true/false or 1/0.")
                 return
+                
+        if len(args) >= 5:
+            arg4 = args[4].lower()
+            if arg4 in ["true", "1", "t", "y", "yes"]:
+                request_crc = True
+            elif arg4 in ["false", "0", "f", "n", "no"]:
+                request_crc = False
+            else:
+                print("invalid request_crc arg. Must be true/false or 1/0.")
+                return
+                
+        if len(args) >= 6:
+            arg5 = args[5].lower()
+            if arg5 in ["true", "1", "t", "y", "yes"]:
+                confirm_image = True
+            elif arg5 in ["false", "0", "f", "n", "no"]:
+                confirm_image = False
+            else:
+                print("invalid confirm_image arg. Must be true/false or 1/0.")
+                return
 
         response = self._send_packet(
-            EdlCommandCode.CO_NODE_FLASH, (node_id, filename, throttle_delay, block_transfer)
+            EdlCommandCode.CO_NODE_FLASH, (node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image)
         )
         if response is not None:
             print(f"Flash command sent. Response: {response}")

--- a/tests/services/test_node_flasher.py
+++ b/tests/services/test_node_flasher.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from oresat_c3.services.node_flasher import (
     FLASH_STATUS_OK,
+    PROGRAM_CTRL_ZEPHYR_CONFIRM,
     NodeFlasherService,
 )
 
@@ -52,6 +53,7 @@ class TestNodeFlasherService(unittest.TestCase):
             node_mgr=self.mock_node_mgr,
             throttle_delay=0.0,
             request_crc=False,
+            confirm_image=False,
         )
 
         self.service.node = MagicMock()
@@ -72,12 +74,14 @@ class TestNodeFlasherService(unittest.TestCase):
                 "filename": "fw.bin",
                 "throttle_delay": 0.5,
                 "block_transfer": True,
+                "request_crc": True,
+                "confirm_image": True,
             }
         )
 
         self.service.on_loop()
 
-        mock_execute.assert_called_once_with(TEST_NODE_ID, "fw.bin", 0.5, True)
+        mock_execute.assert_called_once_with(TEST_NODE_ID, "fw.bin", 0.5, True, True, True)
 
     @patch.object(NodeFlasherService, "_execute_flash")
     def test_on_loop_empty(self, mock_execute):
@@ -94,14 +98,20 @@ class TestNodeFlasherService(unittest.TestCase):
         self.assertEqual(cmd["filename"], "fw1.bin")
         self.assertEqual(cmd["throttle_delay"], 0.0)
         self.assertEqual(cmd["block_transfer"], True)
+        self.assertEqual(cmd["request_crc"], False)
+        self.assertEqual(cmd["confirm_image"], False)
 
         # Test overrides
-        self.service.enqueue_flash(0x7C, "fw2.bin", throttle_delay=0.05, block_transfer=False)
+        self.service.enqueue_flash(
+            0x7C, "fw2.bin", throttle_delay=0.05, block_transfer=False, request_crc=True, confirm_image=True
+        )
         cmd = self.service.command_queue.get(timeout=1.0)
         self.assertEqual(cmd["node_id"], 0x7C)
         self.assertEqual(cmd["filename"], "fw2.bin")
         self.assertEqual(cmd["throttle_delay"], 0.05)
         self.assertEqual(cmd["block_transfer"], False)
+        self.assertEqual(cmd["request_crc"], True)
+        self.assertEqual(cmd["confirm_image"], True)
 
     @patch("oresat_c3.services.node_flasher.time.sleep")
     def test_execute_flash_success(self, mock_sleep):
@@ -113,10 +123,11 @@ class TestNodeFlasherService(unittest.TestCase):
         self.mock_data_sdo.open.return_value = mock_outfile
 
         self.service._execute_flash(
-            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.0, block_transfer=True
+            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=True, confirm_image=True
         )
 
         self.mock_node_mgr.set_node_updating.assert_any_call(TEST_NODE_ID, True)
+        
         self.assertEqual(self.mock_target_node.nmt.state, "PRE-OPERATIONAL")
 
         # Assert SDO operations
@@ -125,11 +136,13 @@ class TestNodeFlasherService(unittest.TestCase):
             buffering=self.service.download_buffer_size,
             size=len(DUMMY_FIRMWARE_DATA),
             block_transfer=True,
-            request_crc_support=False,
+            request_crc_support=True,
         )
         mock_outfile.write.assert_called_once_with(DUMMY_FIRMWARE_DATA)
         self.mock_target_node.nmt.wait_for_bootup.assert_called_once()
         self.mock_node_mgr.set_node_updating.assert_called_with(TEST_NODE_ID, False)
+        
+        self.assertEqual(self.mock_ctrl_sdo.raw, PROGRAM_CTRL_ZEPHYR_CONFIRM)
 
         # Ensure file was cleaned up
         self.assertFalse(os.path.exists(self.test_filepath))
@@ -142,7 +155,7 @@ class TestNodeFlasherService(unittest.TestCase):
         original_send = self.service.node.network._network.bus.send
 
         self.service._execute_flash(
-            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.1, block_transfer=True
+            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.1, block_transfer=True, request_crc=False, confirm_image=False
         )
 
         self.assertEqual(self.service.node.network._network.bus.send, original_send)
@@ -151,19 +164,23 @@ class TestNodeFlasherService(unittest.TestCase):
     def test_execute_flash_file_not_found(self):
         """Test when file is missing."""
         self.service._execute_flash(
-            TEST_NODE_ID, "missing.bin", throttle_delay=0.0, block_transfer=True
+            TEST_NODE_ID, "missing.bin", throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
         )
         self.mock_node_mgr.set_node_updating.assert_not_called()
 
     def test_execute_flash_invalid_node(self):
         """Test when node ID is invalid or not in network."""
         # Unmapped node ID
-        self.service._execute_flash(0x9999, TEST_FILENAME, throttle_delay=0.0, block_transfer=True)
+        self.service._execute_flash(
+            0x9999, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
+        )
         self.mock_node_mgr.set_node_updating.assert_not_called()
 
         # Node mapped but not in remote_nodes
         self.mock_node_mgr.node_id_to_name[0x98] = "weird_node"
-        self.service._execute_flash(0x98, TEST_FILENAME, throttle_delay=0.0, block_transfer=True)
+        self.service._execute_flash(
+            0x98, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
+        )
         self.mock_node_mgr.set_node_updating.assert_not_called()
 
     @patch("oresat_c3.services.node_flasher.time.sleep")
@@ -176,7 +193,7 @@ class TestNodeFlasherService(unittest.TestCase):
         self.service.status_timeout = 0.1
 
         self.service._execute_flash(
-            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.0, block_transfer=True
+            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
         )
 
         self.mock_node_mgr.set_node_updating.assert_called_with(TEST_NODE_ID, False)

--- a/tests/services/test_node_flasher.py
+++ b/tests/services/test_node_flasher.py
@@ -103,7 +103,12 @@ class TestNodeFlasherService(unittest.TestCase):
 
         # Test overrides
         self.service.enqueue_flash(
-            0x7C, "fw2.bin", throttle_delay=0.05, block_transfer=False, request_crc=True, confirm_image=True
+            0x7C,
+            "fw2.bin",
+            throttle_delay=0.05,
+            block_transfer=False,
+            request_crc=True,
+            confirm_image=True,
         )
         cmd = self.service.command_queue.get(timeout=1.0)
         self.assertEqual(cmd["node_id"], 0x7C)
@@ -123,11 +128,16 @@ class TestNodeFlasherService(unittest.TestCase):
         self.mock_data_sdo.open.return_value = mock_outfile
 
         self.service._execute_flash(
-            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=True, confirm_image=True
+            TEST_NODE_ID,
+            TEST_FILENAME,
+            throttle_delay=0.0,
+            block_transfer=True,
+            request_crc=True,
+            confirm_image=True,
         )
 
         self.mock_node_mgr.set_node_updating.assert_any_call(TEST_NODE_ID, True)
-        
+
         self.assertEqual(self.mock_target_node.nmt.state, "PRE-OPERATIONAL")
 
         # Assert SDO operations
@@ -141,7 +151,7 @@ class TestNodeFlasherService(unittest.TestCase):
         mock_outfile.write.assert_called_once_with(DUMMY_FIRMWARE_DATA)
         self.mock_target_node.nmt.wait_for_bootup.assert_called_once()
         self.mock_node_mgr.set_node_updating.assert_called_with(TEST_NODE_ID, False)
-        
+
         self.assertEqual(self.mock_ctrl_sdo.raw, PROGRAM_CTRL_ZEPHYR_CONFIRM)
 
         # Ensure file was cleaned up
@@ -155,7 +165,12 @@ class TestNodeFlasherService(unittest.TestCase):
         original_send = self.service.node.network._network.bus.send
 
         self.service._execute_flash(
-            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.1, block_transfer=True, request_crc=False, confirm_image=False
+            TEST_NODE_ID,
+            TEST_FILENAME,
+            throttle_delay=0.1,
+            block_transfer=True,
+            request_crc=False,
+            confirm_image=False,
         )
 
         self.assertEqual(self.service.node.network._network.bus.send, original_send)
@@ -164,7 +179,12 @@ class TestNodeFlasherService(unittest.TestCase):
     def test_execute_flash_file_not_found(self):
         """Test when file is missing."""
         self.service._execute_flash(
-            TEST_NODE_ID, "missing.bin", throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
+            TEST_NODE_ID,
+            "missing.bin",
+            throttle_delay=0.0,
+            block_transfer=True,
+            request_crc=False,
+            confirm_image=False,
         )
         self.mock_node_mgr.set_node_updating.assert_not_called()
 
@@ -172,14 +192,24 @@ class TestNodeFlasherService(unittest.TestCase):
         """Test when node ID is invalid or not in network."""
         # Unmapped node ID
         self.service._execute_flash(
-            0x9999, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
+            0x9999,
+            TEST_FILENAME,
+            throttle_delay=0.0,
+            block_transfer=True,
+            request_crc=False,
+            confirm_image=False,
         )
         self.mock_node_mgr.set_node_updating.assert_not_called()
 
         # Node mapped but not in remote_nodes
         self.mock_node_mgr.node_id_to_name[0x98] = "weird_node"
         self.service._execute_flash(
-            0x98, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
+            0x98,
+            TEST_FILENAME,
+            throttle_delay=0.0,
+            block_transfer=True,
+            request_crc=False,
+            confirm_image=False,
         )
         self.mock_node_mgr.set_node_updating.assert_not_called()
 
@@ -193,7 +223,12 @@ class TestNodeFlasherService(unittest.TestCase):
         self.service.status_timeout = 0.1
 
         self.service._execute_flash(
-            TEST_NODE_ID, TEST_FILENAME, throttle_delay=0.0, block_transfer=True, request_crc=False, confirm_image=False
+            TEST_NODE_ID,
+            TEST_FILENAME,
+            throttle_delay=0.0,
+            block_transfer=True,
+            request_crc=False,
+            confirm_image=False,
         )
 
         self.mock_node_mgr.set_node_updating.assert_called_with(TEST_NODE_ID, False)


### PR DESCRIPTION
This PR adds the ability for the Node Flasher Service to request a CRC check on the Zephyr image transferred to nodes, and the ability for C3 to confirm an image immediately after transferring.

In the flash_canopen.py script contained in oresat-template-app, there were options for enabling/disabling a CRC check for transferred Zephyr images, as well as the option. This functionality was mistakenly not implemented in the Node Flasher Service, so this PR makes parity between the two.

I previously encountered issues with the CRC check failing even when an image was in a good state. However, I am no longer able to reproduce the issue at all, even going back to old commits. Pete also never encountered the issue on his setup, so I believe it is safe to default request_crc to true now.