### PR TITLE
Fix starting node flasher service

### DIFF
--- a/oresat_c3/__main__.py
+++ b/oresat_c3/__main__.py
@@ -159,6 +159,7 @@ def main():
     app.add_service(edl_service)
     app.add_service(node_mgr_service)
     app.add_service(adcs_mgr_service)
+    app.add_service(node_flasher_service)
 
     for file_name in os.listdir(f"{path}/templates"):
         rest_api.add_template(f"{path}/templates/{file_name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "fastcrc~=0.3",
     "numpy>=1.19.5",
     "oresat-configs>=1.2.0",
-    "oresat-olaf>=3.7.2",
+    "oresat-olaf>=3.7.4",
     "scipy>=1.6.0",
     "skyfield>=1.54",
     "smbus2",


### PR DESCRIPTION
Adding the ADCS service looks like it conflicted with the node flasher service and the node flasher service was never started. Fixes that.