### PR TITLE
Downgrade typing-extensions to 4.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "smbus2",
     "spacepackets>=0.30.1",
     "ccsds-cop>=0.0.0",
-    "typing-extensions>=4.15.0"
+    "typing-extensions>=4.13.0"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
For reasons I only marginally understand 4.15 breaks our linux-images build. I think it comes already installed on the system but without any metadata so removing it fails. Hopefully this all goes away when we migrate to a newer Python.