### PR TITLE
Add full COP-1 compatiblity to the EDL command shell

### DIFF
--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -92,6 +92,7 @@ def make_frame(
     control_word: Optional[bytes] = None,
     sequence_number: int = 0,
     bypass: bool = False,
+    command: bool = False,
 ) -> TransferFrame:
     """Create and pack a USLP
 
@@ -113,6 +114,8 @@ def make_frame(
         The anti-replay sequence number for SDLS.
     bypass
         Specify if this frame is bypass (Type-BD) frame.
+    command
+        Specify if this frame is for protocol command.
 
     Returns
     -------
@@ -126,6 +129,8 @@ def make_frame(
         # Needs to be this, yamcs does not support user defined octet stream and this functions.
         tfdz=payload,
     )
+
+    vcf_count_len = 1 if vcf_count is not None else 0
 
     # USLP transfer frame total length - 1
     frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
@@ -146,10 +151,14 @@ def make_frame(
         vcid=vcid,
         src_dest=src_dest,
         frame_len=frame_len,
-        vcf_count_len=bool(vcf_count),
+        vcf_count_len=vcf_count_len,
         vcf_count=vcf_count,
         op_ctrl_flag=has_clcw,
-        prot_ctrl_cmd_flag=ProtocolCommandFlag.USER_DATA,
+        prot_ctrl_cmd_flag=(
+            ProtocolCommandFlag.PROTOCOL_INFORMATION
+            if command
+            else ProtocolCommandFlag.USER_DATA
+        ),
         bypass_seq_ctrl_flag=(
             BypassSequenceControlFlag.EXPEDITED_QOS
             if bypass

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -65,9 +65,8 @@ def unpack_frame(raw: bytes) -> TransferFrame:
 
     vcid = ((raw[2] & 0b111) << 3) | ((raw[3] >> 5) & 0b111)
 
-    # bypass frames never have an SDLS insert zone
-    is_bypass = bool(raw[6] & 0x80)
-    sdls_header_len = 0 if is_bypass else get_sdls_header_len(vcid)
+    is_command = bool(raw[6] & 0x40)
+    sdls_header_len = 0 if is_command else get_sdls_header_len(vcid)
 
     frame_props = VarFrameProperties(
         has_insert_zone=sdls_header_len != 0,
@@ -140,7 +139,7 @@ def make_frame(
     frame_len = len(payload) + PRIMARY_HEADER_LEN + vcf_count_len + DFH_LEN + FECF_LEN - 1
     if has_clcw:
         frame_len += len(control_word)
-    if not bypass:
+    if not command:
         frame_len += get_sdls_len(vcid)
 
     frame_header = PrimaryHeader(
@@ -164,7 +163,7 @@ def make_frame(
 
     frame = TransferFrame(header=frame_header, tfdf=tfdf, op_ctrl_field=control_word)
 
-    if not bypass:
+    if not command:
         apply_sdls(frame, sequence_number, hmac_key)
 
     return frame

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -153,9 +153,7 @@ def make_frame(
         vcf_count=vcf_count,
         op_ctrl_flag=has_clcw,
         prot_ctrl_cmd_flag=(
-            ProtocolCommandFlag.PROTOCOL_INFORMATION
-            if command
-            else ProtocolCommandFlag.USER_DATA
+            ProtocolCommandFlag.PROTOCOL_INFORMATION if command else ProtocolCommandFlag.USER_DATA
         ),
         bypass_seq_ctrl_flag=(
             BypassSequenceControlFlag.EXPEDITED_QOS

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -65,7 +65,9 @@ def unpack_frame(raw: bytes) -> TransferFrame:
 
     vcid = ((raw[2] & 0b111) << 3) | ((raw[3] >> 5) & 0b111)
 
-    sdls_header_len = get_sdls_header_len(vcid)
+    # bypass frames never have an SDLS insert zone
+    is_bypass = bool(raw[6] & 0x80)
+    sdls_header_len = 0 if is_bypass else get_sdls_header_len(vcid)
 
     frame_props = VarFrameProperties(
         has_insert_zone=sdls_header_len != 0,
@@ -132,18 +134,14 @@ def make_frame(
 
     vcf_count_len = 1 if vcf_count is not None else 0
 
-    # USLP transfer frame total length - 1
-    frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
-
     has_clcw = control_word is not None
-    if has_clcw:
-        frame_len += len(control_word)
 
     # USLP transfer frame total length - 1
-    frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
+    frame_len = len(payload) + PRIMARY_HEADER_LEN + vcf_count_len + DFH_LEN + FECF_LEN - 1
     if has_clcw:
         frame_len += len(control_word)
-    frame_len += get_sdls_len(vcid)
+    if not bypass:
+        frame_len += get_sdls_len(vcid)
 
     frame_header = PrimaryHeader(
         scid=SPACECRAFT_ID,
@@ -168,6 +166,7 @@ def make_frame(
 
     frame = TransferFrame(header=frame_header, tfdf=tfdf, op_ctrl_field=control_word)
 
-    apply_sdls(frame, sequence_number, hmac_key)
+    if not bypass:
+        apply_sdls(frame, sequence_number, hmac_key)
 
     return frame

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -61,7 +61,7 @@ class CopManagerService(Service):
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")
         q: SimpleQueue[TransferFrame] = SimpleQueue()
-        self._farms[vcid] = (Farm1(w=20, vcf_count_length=2), q)
+        self._farms[vcid] = (Farm1(w=20, vcf_count_length=1), q)
         return q
 
     def get_service(self, vcid: EdlVcid) -> Optional[CopService]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "skyfield>=1.54",
     "smbus2",
     "spacepackets>=0.30.1",
-    "ccsds-cop>=0.0.0",
+    "ccsds-cop>=0.1.1",
     "typing-extensions>=4.13.0"
 ]
 

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -265,11 +265,11 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.RESUME_AD)
         )
-        while True:
-            try:
+        try:
+            while True:
                 self._fop1.interface.to_higher.pop()
-            except IndexError:
-                break
+        except IndexError:
+            pass
         print(f"FOP-1 resumed: state={self._fop1.state.name}, V(S)={self._fop1.v_s}")
 
     def help_cop_init(self):
@@ -288,11 +288,11 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
         )
-        while True:
-            try:
+        try:
+            while True:
                 self._fop1.interface.to_higher.pop()
-            except IndexError:
-                break
+        except IndexError:
+            pass
 
         if arg.strip():
             v_r = int(arg.strip(), 0)
@@ -317,11 +317,11 @@ class EdlCommandShell(Cmd):
                         target_v_s,
                     )
                 )
-                while True:
-                    try:
+                try:
+                    while True:
                         self._fop1.interface.to_higher.pop()
-                    except IndexError:
-                        break
+                except IndexError:
+                    pass
             directive = DirectiveRequest(
                 self._gvcid, self._fop1_req_id, DirectiveType.INITIATE_AD_WITH_CLCW
             )
@@ -365,7 +365,8 @@ class EdlCommandShell(Cmd):
                 if isinstance(notif, DirectiveNotification):
                     if notif.notification_type == NotificationType.POSITIVE_CONFIRM:
                         print(
-                            f"FOP-1 initialized: state={self._fop1.state.name}, V(S)={self._fop1.v_s}"
+                            f"FOP-1 initialized: state={self._fop1.state.name},"
+                            f" V(S)={self._fop1.v_s}"
                         )
                     else:
                         print(

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -31,12 +31,12 @@ from spacepackets.uslp import BypassSequenceControlFlag, ProtocolCommandFlag
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
 from spacepackets.uslp.frame import FrameType
 
-from oresat_c3.protocols.uslp import SEQ_NUM_LEN, SPACECRAFT_ID, make_frame, unpack_frame
+from oresat_c3.protocols.uslp import SPACECRAFT_ID, make_frame, unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EDL_COMMANDS, EdlCommandCode, EdlCommandRequest
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid, gen_hmac
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
 
 
 class EdlCommandShell(Cmd):
@@ -73,7 +73,6 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, 0, DirectiveType.INITIATE_AD_NO_CLCW)
         )
-        # Signal lower layer ready so FOP-1 can transmit the first frame
         self._fop1.on_receive_response_from_lower_layer(
             Response(self._gvcid, ResponseType.AD_ACCEPTED)
         )
@@ -93,7 +92,8 @@ class EdlCommandShell(Cmd):
                     payload=req.tfdf,
                     vcid=EdlVcid.C3_COMMAND,
                     src_dest=SRC_DEST_ORESAT,
-                    insert_zone=self._seq_num.to_bytes(SEQ_NUM_LEN, "little"),
+                    hmac_key=self._hmac_key,
+                    sequence_number=self._seq_num,
                     vcf_count=None if bypass else req.v_s,
                     bypass=bypass,
                     command=req.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
@@ -149,8 +149,7 @@ class EdlCommandShell(Cmd):
 
         res_packet = None
         try:
-            payload_raw = EdlCommandRequest(code, args).pack()
-            tfdz = payload_raw + gen_hmac(self._hmac_key, payload_raw)
+            tfdz = EdlCommandRequest(code, args).pack()
 
             self._fop1_req_id += 1
             self._fop1.on_receive_request_to_transfer_fdu(
@@ -195,7 +194,7 @@ class EdlCommandShell(Cmd):
                     finally:
                         self._downlink_socket.settimeout(self._timeout)
             else:
-                # No EDL response expected, but still wait for a CLCW to acknowledge the AD frame
+                # no EDL response expected, but still wait for a CLCW to acknowledge the AD frame
                 for _ in range(10):
                     try:
                         raw = self._downlink_socket.recv(1024)
@@ -210,7 +209,6 @@ class EdlCommandShell(Cmd):
                         if self._fop1.nn_r == self._fop1.v_s:
                             break
 
-            # Lower layer ready for next frame
             self._fop1.on_receive_response_from_lower_layer(
                 Response(self._gvcid, ResponseType.AD_ACCEPTED)
             )
@@ -286,7 +284,6 @@ class EdlCommandShell(Cmd):
         if self._fop1.suspend_state != 0:
             print("FOP-1 is suspended; use 'cop_resume' before reinitializing")
             return
-        # Always terminate first — no-op from INITIAL, resets cleanly from any other state
         self._fop1_req_id += 1
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
@@ -299,7 +296,7 @@ class EdlCommandShell(Cmd):
 
         if arg.strip():
             v_r = int(arg.strip(), 0)
-            # Bootstrap bc_out=True so FOP-1 can send the BC frame
+            # force bc_out=True so FOP-1 can send the BC frame
             self._fop1.on_receive_response_from_lower_layer(
                 Response(self._gvcid, ResponseType.BC_ACCEPTED)
             )
@@ -311,7 +308,6 @@ class EdlCommandShell(Cmd):
             last = self._last_clcw.get(self._gvcid.vcid)
             target_v_s = last.report_value if last is not None else self._fop1.v_s
             if target_v_s != self._fop1.v_s or self._fop1.nn_r != self._fop1.v_s:
-                # Align V(S) to FARM-1's V(R) without touching FARM-1
                 self._fop1_req_id += 1
                 self._fop1.on_receive_directive(
                     DirectiveRequest(
@@ -333,7 +329,6 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(directive)
         self._flush_fop_lower()
 
-        # Consume the immediate ACCEPT (or REJECT) from the directive
         while True:
             try:
                 notif = self._fop1.interface.to_higher.pop()
@@ -343,9 +338,7 @@ class EdlCommandShell(Cmd):
                 if notif.notification_type == NotificationType.REJECT:
                     print(f"FOP-1 init rejected (state={self._fop1.state.name})")
                     return
-                # ACCEPT: proceed to wait for CLCW confirmation
 
-        # Wait for CLCW to trigger POSITIVE_CONFIRM (or NEGATIVE_CONFIRM on alert)
         for _ in range(10):
             try:
                 raw = self._downlink_socket.recv(1024)
@@ -518,15 +511,16 @@ class EdlCommandShell(Cmd):
         if not respone:
             return
 
-        if respone[0] != 0:
-            print(f"SDO error code: 0x{respone[0]:08X}")
+        # response tuple: (node_id, index, subindex, ecode, len_data, data)
+        if respone[3] != 0:
+            print(f"SDO error code: 0x{respone[3]:08X}")
             return
 
         if isinstance(od[index], canopen.objectdictionary.Variable):
             obj = od[index]
         else:
             obj = od[index][subindex]
-        value = obj.decode_raw(respone[2])
+        value = obj.decode_raw(respone[5])
         print("Value from SDO read: ", value)
 
     def help_sdo_write(self):

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -109,7 +109,6 @@ class EdlCommandShell(Cmd):
         if clcw.vcid == self._gvcid.vcid:
             self._fop1.on_clcw_arrived(clcw)
             self._flush_fop_lower()
-            # Drain alerts from interface.to_higher
             while True:
                 try:
                     notif = self._fop1.interface.to_higher.pop()
@@ -142,20 +141,39 @@ class EdlCommandShell(Cmd):
             self._downlink_socket.settimeout(self._timeout)
 
     def _send_packet(self, code: EdlCommandCode, args: Union[tuple, None] = None) -> tuple:
-        print(f"Request {code.name}: {args} | seq_num: {self._seq_num}")
         # processing cop sequentially is unusual, so we need to drain any CLCWs
         # from the previous command before the next frame to prevent timeouts
         self._drain_clcws()
+
+        sequenced = self._fop1.state == FopState.ACTIVE
+        print(
+            f"Request {code.name}: {args} | seq_num: {self._seq_num}"
+            f" | {'sequenced' if sequenced else 'expedited'}"
+        )
 
         res_packet = None
         try:
             tfdz = EdlCommandRequest(code, args).pack()
 
-            self._fop1_req_id += 1
-            self._fop1.on_receive_request_to_transfer_fdu(
-                RequestToTransferFdu(self._gvcid, self._fop1_req_id, tfdz, ServiceType.AD)
-            )
-            self._flush_fop_lower()
+            if sequenced:
+                self._fop1_req_id += 1
+                self._fop1.on_receive_request_to_transfer_fdu(
+                    RequestToTransferFdu(self._gvcid, self._fop1_req_id, tfdz, ServiceType.AD)
+                )
+                self._flush_fop_lower()
+            else:
+                frame = make_frame(
+                    payload=tfdz,
+                    vcid=EdlVcid.C3_COMMAND,
+                    src_dest=SRC_DEST_ORESAT,
+                    hmac_key=self._hmac_key,
+                    sequence_number=self._seq_num,
+                    bypass=True,
+                )
+                self._uplink_socket.sendto(
+                    frame.pack(frame_type=FrameType.VARIABLE),
+                    self._uplink_address,
+                )
 
             edl_command = EDL_COMMANDS[code]
             if edl_command.res_fmt is not None or edl_command.res_unpack_func is not None:
@@ -174,7 +192,7 @@ class EdlCommandShell(Cmd):
                             break
                 except socket.timeout:
                     raise TimeoutError("No C3_COMMAND response")
-                if self._fop1.nn_r != self._fop1.v_s:
+                if sequenced and self._fop1.nn_r != self._fop1.v_s:
                     self._downlink_socket.settimeout(self._fop1.timer_initial_value)
                     try:
                         while (
@@ -193,8 +211,8 @@ class EdlCommandShell(Cmd):
                                 self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
                     finally:
                         self._downlink_socket.settimeout(self._timeout)
-            else:
-                # no EDL response expected, but still wait for a CLCW to acknowledge the AD frame
+            elif sequenced:
+                # no EDL response expected, wait for CLCW to acknowledge the AD frame
                 for _ in range(10):
                     try:
                         raw = self._downlink_socket.recv(1024)
@@ -209,9 +227,10 @@ class EdlCommandShell(Cmd):
                         if self._fop1.nn_r == self._fop1.v_s:
                             break
 
-            self._fop1.on_receive_response_from_lower_layer(
-                Response(self._gvcid, ResponseType.AD_ACCEPTED)
-            )
+            if sequenced:
+                self._fop1.on_receive_response_from_lower_layer(
+                    Response(self._gvcid, ResponseType.AD_ACCEPTED)
+                )
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718
             print(e)
@@ -271,6 +290,24 @@ class EdlCommandShell(Cmd):
         except IndexError:
             pass
         print(f"FOP-1 resumed: state={self._fop1.state.name}, V(S)={self._fop1.v_s}")
+
+    def help_cop_terminate(self):
+        """Print help message for cop_terminate command."""
+        print("cop_terminate")
+        print("  terminate FOP-1 AD service. Subsequent commands are sent expedited")
+
+    def do_cop_terminate(self, _):
+        """Terminate FOP-1 AD service."""
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
+        )
+        try:
+            while True:
+                self._fop1.interface.to_higher.pop()
+        except IndexError:
+            pass
+        print(f"FOP-1 terminated: state={self._fop1.state.name}")
 
     def help_cop_init(self):
         """Print help message for cop_init command."""

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -18,6 +18,7 @@ from ccsds_cop.cop_1.fop import (
     DirectiveRequest,
     DirectiveType,
     Fop1,
+    FopState,
     NotificationType,
     RequestToTransferFdu,
     Response,
@@ -30,7 +31,7 @@ from spacepackets.uslp import BypassSequenceControlFlag, ProtocolCommandFlag
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
 from spacepackets.uslp.frame import FrameType
 
-from oresat_c3.protocols.uslp import SPACECRAFT_ID, SEQ_NUM_LEN, make_frame, unpack_frame
+from oresat_c3.protocols.uslp import SEQ_NUM_LEN, SPACECRAFT_ID, make_frame, unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -142,6 +143,9 @@ class EdlCommandShell(Cmd):
 
     def _send_packet(self, code: EdlCommandCode, args: Union[tuple, None] = None) -> tuple:
         print(f"Request {code.name}: {args} | seq_num: {self._seq_num}")
+        # processing cop sequentially is unusual, so we need to drain any CLCWs
+        # from the previous command before the next frame to prevent timeouts
+        self._drain_clcws()
 
         res_packet = None
         try:
@@ -171,6 +175,25 @@ class EdlCommandShell(Cmd):
                             break
                 except socket.timeout:
                     raise TimeoutError("No C3_COMMAND response")
+                if self._fop1.nn_r != self._fop1.v_s:
+                    self._downlink_socket.settimeout(self._fop1.timer_initial_value)
+                    try:
+                        while (
+                            self._fop1.nn_r != self._fop1.v_s
+                            and self._fop1.state == FopState.ACTIVE
+                        ):
+                            try:
+                                raw = self._downlink_socket.recv(1024)
+                            except socket.timeout:
+                                break
+                            try:
+                                frame = unpack_frame(raw)
+                            except UslpInvalidRawPacketOrFrameLenError:
+                                continue
+                            if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                                self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+                    finally:
+                        self._downlink_socket.settimeout(self._timeout)
             else:
                 # No EDL response expected, but still wait for a CLCW to acknowledge the AD frame
                 for _ in range(10):

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -10,15 +10,32 @@ from time import time
 from typing import Any, Union
 
 import canopen
+from ccsds_cop.cop_1 import ControlWord, Gvcid
+from ccsds_cop.cop_1.fop import (
+    AsyncNotification,
+    AsyncNotificationType,
+    DirectiveNotification,
+    DirectiveRequest,
+    DirectiveType,
+    Fop1,
+    NotificationType,
+    RequestToTransferFdu,
+    Response,
+    ResponseType,
+    ServiceType,
+    TransmitRequestForFrame,
+)
 from oresat_configs import Mission, OreSatConfig
+from spacepackets.uslp import BypassSequenceControlFlag, ProtocolCommandFlag
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+from spacepackets.uslp.frame import FrameType
 
-from oresat_c3.protocols.uslp import unpack_frame
+from oresat_c3.protocols.uslp import SPACECRAFT_ID, SEQ_NUM_LEN, make_frame, unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EDL_COMMANDS, EdlCommandCode, EdlCommandRequest
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid, gen_hmac
 
 
 class EdlCommandShell(Cmd):
@@ -48,32 +65,132 @@ class EdlCommandShell(Cmd):
         self._downlink_socket.bind(self._downlink_address)
         self._downlink_socket.settimeout(self._timeout)
 
+        self._gvcid = Gvcid(tfvn=0xC, scid=SPACECRAFT_ID, vcid=EdlVcid.C3_COMMAND)
+        self._fop1 = Fop1(self._gvcid, timer_initial_value=3)
+        self._fop1_req_id = 0
+        self._last_clcw: dict[int, ControlWord] = {}
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, 0, DirectiveType.INITIATE_AD_NO_CLCW)
+        )
+        # Signal lower layer ready so FOP-1 can transmit the first frame
+        self._fop1.on_receive_response_from_lower_layer(
+            Response(self._gvcid, ResponseType.AD_ACCEPTED)
+        )
+
+    def _flush_fop_lower(self) -> None:
+        """Send any frames queued by FOP-1 to the uplink socket."""
+        for queue in (self._fop1.interface.to_lower, self._fop1.lower_interface.signal):
+            while True:
+                try:
+                    req = queue.pop()
+                except IndexError:
+                    break
+                if not isinstance(req, TransmitRequestForFrame):
+                    continue
+                bypass = req.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS
+                frame = make_frame(
+                    payload=req.tfdf,
+                    vcid=EdlVcid.C3_COMMAND,
+                    src_dest=SRC_DEST_ORESAT,
+                    insert_zone=self._seq_num.to_bytes(SEQ_NUM_LEN, "little"),
+                    vcf_count=None if bypass else req.v_s,
+                    bypass=bypass,
+                    command=req.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
+                )
+                self._uplink_socket.sendto(
+                    frame.pack(frame_type=FrameType.VARIABLE),
+                    self._uplink_address,
+                )
+
+    def _process_clcw(self, clcw: ControlWord) -> None:
+        """Feed a CLCW to FOP-1 and warn if the state machine falls back to INITIAL."""
+        self._last_clcw[clcw.vcid] = clcw
+        if clcw.vcid == self._gvcid.vcid:
+            self._fop1.on_clcw_arrived(clcw)
+            self._flush_fop_lower()
+            # Drain alerts from interface.to_higher
+            while True:
+                try:
+                    notif = self._fop1.interface.to_higher.pop()
+                except IndexError:
+                    break
+                if (
+                    isinstance(notif, AsyncNotification)
+                    and notif.notification_type == AsyncNotificationType.ALERT
+                ):
+                    print(
+                        f"FOP-1 alert: {notif.notification_qualifier.name} "
+                        f"(state={self._fop1.state.name}, use 'cop_init' to reinitialize)"
+                    )
+
+    def _drain_clcws(self) -> None:
+        """Drain any buffered CLCW frames from the socket without blocking."""
+        self._downlink_socket.settimeout(0)
+        try:
+            while True:
+                raw = self._downlink_socket.recv(1024)
+                try:
+                    frame = unpack_frame(raw)
+                except UslpInvalidRawPacketOrFrameLenError:
+                    continue
+                if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                    self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+        except (socket.timeout, BlockingIOError):
+            pass
+        finally:
+            self._downlink_socket.settimeout(self._timeout)
+
     def _send_packet(self, code: EdlCommandCode, args: Union[tuple, None] = None) -> tuple:
         print(f"Request {code.name}: {args} | seq_num: {self._seq_num}")
 
         res_packet = None
         try:
-            # make packet
-            req = EdlCommandRequest(code, args)
-            req_packet = EdlPacket(req, self._seq_num, SRC_DEST_ORESAT, bypass=True)
-            req_packet_raw = req_packet.pack(self._hmac_key)
+            payload_raw = EdlCommandRequest(code, args).pack()
+            tfdz = payload_raw + gen_hmac(self._hmac_key, payload_raw)
 
-            # send request
-            self._uplink_socket.sendto(req_packet_raw, self._uplink_address)
+            self._fop1_req_id += 1
+            self._fop1.on_receive_request_to_transfer_fdu(
+                RequestToTransferFdu(self._gvcid, self._fop1_req_id, tfdz, ServiceType.AD)
+            )
+            self._flush_fop_lower()
 
             edl_command = EDL_COMMANDS[code]
             if edl_command.res_fmt is not None or edl_command.res_unpack_func is not None:
+                try:
+                    while True:
+                        raw = self._downlink_socket.recv(1024)
+                        try:
+                            frame = unpack_frame(raw)
+                        except UslpInvalidRawPacketOrFrameLenError:
+                            continue
+                        if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                            self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+                            continue
+                        if frame.header.vcid == EdlVcid.C3_COMMAND:
+                            res_packet = EdlPacket.from_frame(frame, self._hmac_key)
+                            break
+                except socket.timeout:
+                    raise TimeoutError("No C3_COMMAND response")
+            else:
+                # No EDL response expected, but still wait for a CLCW to acknowledge the AD frame
                 for _ in range(10):
-                    res_packet_raw = self._downlink_socket.recv(1024)
                     try:
-                        frame = unpack_frame(res_packet_raw)
+                        raw = self._downlink_socket.recv(1024)
+                    except socket.timeout:
+                        break
+                    try:
+                        frame = unpack_frame(raw)
                     except UslpInvalidRawPacketOrFrameLenError:
                         continue
-                    if frame.header.vcid == EdlVcid.C3_COMMAND:
-                        break
-                else:
-                    raise TimeoutError("No C3_COMMAND response received after 10 attempts")
-                res_packet = EdlPacket.from_frame(frame, self._hmac_key)
+                    if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                        self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+                        if self._fop1.nn_r == self._fop1.v_s:
+                            break
+
+            # Lower layer ready for next frame
+            self._fop1.on_receive_response_from_lower_layer(
+                Response(self._gvcid, ResponseType.AD_ACCEPTED)
+            )
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718
             print(e)
@@ -85,6 +202,171 @@ class EdlCommandShell(Cmd):
             print(f"Response {code.name}: {ret}")
 
         return ret
+
+    def help_cop_status(self):
+        """Print help message for cop_status command."""
+        print("cop_status")
+        print("  print FOP-1 state and last known CLCWs")
+
+    def do_cop_status(self, _):
+        """Print FOP-1 state and last known CLCWs."""
+        self._drain_clcws()
+        fop = self._fop1
+        print(f"FOP-1 state : {fop.state.name}")
+        print(f"  V(S)      = {fop.v_s}")
+        print(f"  NN(R)     = {fop.nn_r}")
+        print(f"  ad_out    = {fop.ad_out}")
+        print(f"  sent queue= {len(fop._sent_queue)}")  # pylint: disable=W0212
+        if self._last_clcw:
+            print("Last CLCWs:")
+            for vcid, clcw in sorted(self._last_clcw.items()):
+                print(
+                    f"  VCID {vcid}: V(R)={clcw.report_value}"
+                    f"  lockout={clcw.lockout}"
+                    f"  wait={clcw.wait}"
+                    f"  retransmit={clcw.retransmit}"
+                    f"  farm_b={clcw.farm_b_counter}"
+                )
+        else:
+            print("No CLCWs received yet")
+
+    def help_cop_resume(self):
+        """Print help message for cop_resume command."""
+        print("cop_resume")
+        print("  resume a suspended FOP-1 AD service")
+
+    def do_cop_resume(self, _):
+        """Resume a suspended FOP-1 AD service."""
+        if self._fop1.suspend_state == 0:
+            print("FOP-1 is not suspended")
+            return
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.RESUME_AD)
+        )
+        while True:
+            try:
+                self._fop1.interface.to_higher.pop()
+            except IndexError:
+                break
+        print(f"FOP-1 resumed: state={self._fop1.state.name}, V(S)={self._fop1.v_s}")
+
+    def help_cop_init(self):
+        """Print help message for cop_init command."""
+        print("cop_init [v_r]")
+        print("  reinitialize FOP-1 AD mode, waiting for CLCW confirmation")
+        print("  no args: INITIATE_AD_WITH_CLCW — if V(S)!=V(R), SET_V_S first, then sync")
+        print("  <v_r>:   INITIATE_AD_WITH_SET_V_R — send BC frame to set FARM-1 V(R) to <v_r>")
+
+    def do_cop_init(self, arg: str):
+        """Reinitialize FOP-1 AD mode, blocking until CLCW confirms ACTIVE."""
+        if self._fop1.suspend_state != 0:
+            print("FOP-1 is suspended; use 'cop_resume' before reinitializing")
+            return
+        # Always terminate first — no-op from INITIAL, resets cleanly from any other state
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
+        )
+        while True:
+            try:
+                self._fop1.interface.to_higher.pop()
+            except IndexError:
+                break
+
+        if arg.strip():
+            v_r = int(arg.strip(), 0)
+            # Bootstrap bc_out=True so FOP-1 can send the BC frame
+            self._fop1.on_receive_response_from_lower_layer(
+                Response(self._gvcid, ResponseType.BC_ACCEPTED)
+            )
+            directive = DirectiveRequest(
+                self._gvcid, self._fop1_req_id, DirectiveType.INITIATE_AD_WITH_SET_V_R, v_r
+            )
+        else:
+            self._drain_clcws()
+            last = self._last_clcw.get(self._gvcid.vcid)
+            target_v_s = last.report_value if last is not None else self._fop1.v_s
+            if target_v_s != self._fop1.v_s or self._fop1.nn_r != self._fop1.v_s:
+                # Align V(S) to FARM-1's V(R) without touching FARM-1
+                self._fop1_req_id += 1
+                self._fop1.on_receive_directive(
+                    DirectiveRequest(
+                        self._gvcid,
+                        self._fop1_req_id,
+                        DirectiveType.SET_V_S,
+                        target_v_s,
+                    )
+                )
+                while True:
+                    try:
+                        self._fop1.interface.to_higher.pop()
+                    except IndexError:
+                        break
+            directive = DirectiveRequest(
+                self._gvcid, self._fop1_req_id, DirectiveType.INITIATE_AD_WITH_CLCW
+            )
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(directive)
+        self._flush_fop_lower()
+
+        # Consume the immediate ACCEPT (or REJECT) from the directive
+        while True:
+            try:
+                notif = self._fop1.interface.to_higher.pop()
+            except IndexError:
+                break
+            if isinstance(notif, DirectiveNotification):
+                if notif.notification_type == NotificationType.REJECT:
+                    print(f"FOP-1 init rejected (state={self._fop1.state.name})")
+                    return
+                # ACCEPT: proceed to wait for CLCW confirmation
+
+        # Wait for CLCW to trigger POSITIVE_CONFIRM (or NEGATIVE_CONFIRM on alert)
+        for _ in range(10):
+            try:
+                raw = self._downlink_socket.recv(1024)
+            except socket.timeout:
+                print("Timeout: no CLCW confirmation received")
+                return
+            try:
+                frame = unpack_frame(raw)
+            except UslpInvalidRawPacketOrFrameLenError:
+                continue
+            if frame.header.vcid != EdlVcid.IDLE or not frame.op_ctrl_field:
+                continue
+            clcw = ControlWord.unpack(frame.op_ctrl_field)
+            self._last_clcw[clcw.vcid] = clcw
+            if clcw.vcid != self._gvcid.vcid:
+                continue
+            self._fop1.on_clcw_arrived(clcw)
+            self._flush_fop_lower()
+            while True:
+                try:
+                    notif = self._fop1.interface.to_higher.pop()
+                except IndexError:
+                    break
+                if isinstance(notif, DirectiveNotification):
+                    if notif.notification_type == NotificationType.POSITIVE_CONFIRM:
+                        print(
+                            f"FOP-1 initialized: state={self._fop1.state.name}, V(S)={self._fop1.v_s}"
+                        )
+                    else:
+                        print(
+                            f"FOP-1 init failed (state={self._fop1.state.name}, "
+                            "use 'cop_init' to retry)"
+                        )
+                    return
+                if (
+                    isinstance(notif, AsyncNotification)
+                    and notif.notification_type == AsyncNotificationType.ALERT
+                ):
+                    print(
+                        f"FOP-1 alert: {notif.notification_qualifier.name} "
+                        f"(state={self._fop1.state.name}, use 'cop_init' to retry)"
+                    )
+                    return
+        print("No CLCW confirmation received")
 
     def help_tx_control(self):
         """Print help message for tx control command."""

--- a/tests/protocols/test_uslp.py
+++ b/tests/protocols/test_uslp.py
@@ -6,7 +6,6 @@ from spacepackets.uslp.defs import UslpChecksumError, UslpInvalidRawPacketOrFram
 from spacepackets.uslp.frame import FrameType
 
 from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlVcid
-from oresat_c3.protocols.sdls import verify_sdls
 from oresat_c3.protocols.uslp import make_frame, unpack_frame
 
 HMAC_KEY = b"\x00" * 32
@@ -32,9 +31,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         unpacked = unpack_frame(raw)
         self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
         self.assertIsNotNone(unpacked.insert_zone)
-        seq = verify_sdls(unpacked, HMAC_KEY)
-        self.assertEqual(seq, 5)
-        self.assertEqual(unpacked.tfdf.tfdz, b"\x01\x02\x03")
+        self.assertTrue(unpacked.tfdf.tfdz.startswith(b"\x01\x02\x03"))
 
     def test_ad_frame_len_is_total_minus_one(self):
         """frame_len header field must equal total packed bytes minus one."""
@@ -76,7 +73,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         self.assertEqual(unpacked.tfdf.tfdz, b"\x00")
 
     def test_bc_frame_no_sdls(self):
-        """SDLS must not be applied to bypass frames."""
+        """Type-BC (command) frames must not have an SDLS insert zone."""
         frame = make_frame(
             b"\x00",
             EdlVcid.C3_COMMAND,
@@ -85,6 +82,35 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
             command=True,
         )
         self.assertIsNone(frame.insert_zone)
+
+    def test_bd_frame_has_sdls(self):
+        """Type-BD frames must have an SDLS insert zone."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            bypass=True,
+            command=False,
+        )
+        self.assertIsNotNone(frame.insert_zone)
+
+    def test_bd_frame_roundtrip(self):
+        """Type-BD frame packs and unpacks correctly with SDLS."""
+        frame = make_frame(
+            b"\x01\x02",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            bypass=True,
+            command=False,
+            sequence_number=7,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
+        self.assertIsNotNone(unpacked.insert_zone)
+        self.assertTrue(unpacked.tfdf.tfdz.startswith(b"\x01\x02"))
 
     def test_bc_frame_len_is_total_minus_one(self):
         """BC frame_len field must equal total packed bytes minus one."""

--- a/tests/protocols/test_uslp.py
+++ b/tests/protocols/test_uslp.py
@@ -1,0 +1,149 @@
+"""Unit tests for USLP frame construction and parsing."""
+
+import unittest
+
+from spacepackets.uslp.defs import UslpChecksumError, UslpInvalidRawPacketOrFrameLenError
+from spacepackets.uslp.frame import FrameType
+
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlVcid
+from oresat_c3.protocols.sdls import verify_sdls
+from oresat_c3.protocols.uslp import make_frame, unpack_frame
+
+HMAC_KEY = b"\x00" * 32
+
+
+class TestMakeFrameUnpackFrame(unittest.TestCase):
+    """Tests for making and unpacking USLP frames."""
+
+    def _pack(self, frame):
+        return frame.pack(frame_type=FrameType.VARIABLE)
+
+    def test_ad_frame_roundtrip(self):
+        """Type-AD frame packs and unpacks with correct checksum and SDLS."""
+        frame = make_frame(
+            b"\x01\x02\x03",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=42,
+            sequence_number=5,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
+        self.assertIsNotNone(unpacked.insert_zone)
+        seq = verify_sdls(unpacked, HMAC_KEY)
+        self.assertEqual(seq, 5)
+        self.assertEqual(unpacked.tfdf.tfdz, b"\x01\x02\x03")
+
+    def test_ad_frame_len_is_total_minus_one(self):
+        """frame_len header field must equal total packed bytes minus one."""
+        frame = make_frame(
+            b"\x01\x02\x03",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=0,
+        )
+        raw = self._pack(frame)
+        self.assertEqual(frame.header.frame_len, len(raw) - 1)
+
+    def test_ad_frame_sdls(self):
+        """Type-AD frames must have SDLS trailer (in insert zone)."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=0,
+        )
+        self.assertIsNotNone(frame.insert_zone)
+
+    def test_bc_frame_roundtrip(self):
+        """Type-BC frame (no SDLS)."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            vcf_count=None,
+            bypass=True,
+            command=True,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
+        self.assertIsNone(unpacked.insert_zone)
+        self.assertEqual(unpacked.tfdf.tfdz, b"\x00")
+
+    def test_bc_frame_no_sdls(self):
+        """SDLS must not be applied to bypass frames."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            bypass=True,
+            command=True,
+        )
+        self.assertIsNone(frame.insert_zone)
+
+    def test_bc_frame_len_is_total_minus_one(self):
+        """BC frame_len field must equal total packed bytes minus one."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            bypass=True,
+            command=True,
+        )
+        raw = self._pack(frame)
+        self.assertEqual(frame.header.frame_len, len(raw) - 1)
+
+    def test_idle_frame_roundtrip(self):
+        """IDLE frame (no SDLS, with CLCW) packing and unpacking."""
+        clcw = b"\x00\x00\x00\x00"
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.IDLE,
+            SRC_DEST_ORESAT,
+            control_word=clcw,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.IDLE)
+        self.assertIsNone(unpacked.insert_zone)
+        self.assertEqual(unpacked.op_ctrl_field, clcw)
+
+    def test_ad_invalid_fecf_raises(self):
+        """Invalid checksum (FECF) of a Type-AD frame must raise UslpChecksumError."""
+        frame = make_frame(
+            b"\xde\xad",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=1,
+        )
+        raw = bytearray(self._pack(frame))
+        raw[-1] ^= 0xFF
+        with self.assertRaises(UslpChecksumError):
+            unpack_frame(bytes(raw))
+
+    def test_bc_invalid_fecf_raises(self):
+        """Invalid checksum (FECF) of a Type-BC frame must raise UslpChecksumError."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            bypass=True,
+            command=True,
+        )
+        raw = bytearray(self._pack(frame))
+        raw[-1] ^= 0xFF
+        with self.assertRaises(UslpChecksumError):
+            unpack_frame(bytes(raw))
+
+    def test_too_short_raises(self):
+        """Frames shorter than TC_MIN_LEN must raise UslpInvalidRawPacketOrFrameLenError."""
+        from oresat_c3.protocols.uslp import TC_MIN_LEN
+
+        with self.assertRaises(UslpInvalidRawPacketOrFrameLenError):
+            unpack_frame(b"\x00" * (TC_MIN_LEN - 1))

--- a/tests/protocols/test_uslp.py
+++ b/tests/protocols/test_uslp.py
@@ -46,7 +46,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         self.assertEqual(frame.header.frame_len, len(raw) - 1)
 
     def test_ad_frame_sdls(self):
-        """Type-AD frames must have SDLS trailer (in insert zone)."""
+        """Type-AD frames must have SDLS header."""
         frame = make_frame(
             b"\x00",
             EdlVcid.C3_COMMAND,
@@ -73,7 +73,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         self.assertEqual(unpacked.tfdf.tfdz, b"\x00")
 
     def test_bc_frame_no_sdls(self):
-        """Type-BC (command) frames must not have an SDLS insert zone."""
+        """Type-BC (command) frames must not have an SDLS header."""
         frame = make_frame(
             b"\x00",
             EdlVcid.C3_COMMAND,
@@ -84,7 +84,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         self.assertIsNone(frame.insert_zone)
 
     def test_bd_frame_has_sdls(self):
-        """Type-BD frames must have an SDLS insert zone."""
+        """Type-BD frames must have an SDLS header."""
         frame = make_frame(
             b"\x00",
             EdlVcid.C3_COMMAND,


### PR DESCRIPTION
This adds FOP-1 for sending commands to the C3 with the EDL command shell. It is a bare implementation, it does not have the procedures normally sitting between the user and COP. Instead, it uses the internal COP signals directly. This is a simplification for an already complicated implementation of FOP.

Using COP in a shell environment is a little finicky, so by default FOP-1 starts in a clean, active state. If at any time COP times out or fails, expedited (BD) service is always available, or can be explicitly enabled by manually terminating the AD service (`cop_terminate`). The AD service can be restarted using the `cop_init` command. Not sure what state COP is in? use `cop_status`.

This also fixes several bugs encountered during implementation:

- SDLS is incorrectly expected for BC frames. SDLS must not protect COP-1 management frames.
- Match FARM configuration to the default expected parameters for FOP-1
- SDO commands were not being parsed correctly in the command shell