### PR TITLE
Cfdp rework

### DIFF
--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -166,6 +166,9 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
     def list_directory(
         self, _dir_name: Path, file_name: Path, recursive: bool = False
     ) -> FilestoreResult:
+        if not _dir_name.exists() or not _dir_name.is_dir():
+            return FilestoreResult.NOT_PERFORMED
+
         cmd = ["ls", "-al"]
         fullpath = Path(self._dir) / file_name
         with open(fullpath, "w") as of:

--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -29,12 +29,6 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                     with open(self._dir + f.name, "rb") as rf:
                         rf.seek(offset or 0)
                         return rf.read(read_len)
-            # Yamcs needs a filename that does not comply with the oresat filename schema.
-            # We will as a fallback look for .dirlist* after failing to find a normal file.
-            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
-                with open(self._dir + file.name, "rb") as rf:
-                    rf.seek(offset or 0)
-                    return rf.read(read_len)
             raise FileNotFoundError(file)
 
     def file_size(self, file: Path) -> int:
@@ -54,10 +48,7 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
 
     def file_exists(self, path: Path) -> bool:
         with self._lock:
-            return (
-                any(path.name == f.name for f in self._data)
-                or (Path(self._dir) / path).exists()
-            )
+            return (any(path.name == f.name for f in self._data))
 
     def stat(self, file: Path) -> os.stat_result:
         """Implements os.stat() but for a filestore
@@ -71,8 +62,6 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
             for f in self._data:
                 if file.name == f.name:
                     return Path(self._dir, f.name).stat()
-            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
-                return Path(self._dir, file.name).stat()
             raise FileNotFoundError(file)
 
     def truncate_file(self, file: Path) -> None:
@@ -81,9 +70,6 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                 if file.name == f.name:
                     with open(self._dir + f.name, "w"):
                         return
-            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
-                with open(self._dir + file.name, "w"):
-                    return
             raise FileNotFoundError(file)
 
     def write_data(self, file: Path, data: bytes, offset: Optional[int] = None) -> None:
@@ -121,9 +107,6 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                     os.remove(self._dir + f.name)
                     self._data.remove(f)
                     return FilestoreResult.DELETE_SUCCESS
-            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
-                os.remove(self._dir + file.name)
-                return FilestoreResult.DELETE_SUCCESS
             return FilestoreResult.DELETE_FILE_DOES_NOT_EXIST
 
     def rename_file(self, old_file: Path, new_file: Path) -> FilestoreResult:
@@ -167,9 +150,12 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
         self, _dir_name: Path, file_name: Path, recursive: bool = False
     ) -> FilestoreResult:
         cmd = ["ls", "-al"]
+
+        if not self.file_exists(file_name):
+            self.create_file(file_name)
+
         fullpath = Path(self._dir) / file_name
         with open(fullpath, "w") as of:
-            of.write(f"Contents of directory {_dir_name} generated with '{cmd}':\n")
             try:
                 result = subprocess.run(cmd, check=True, capture_output=True, cwd=self._dir)
             except (subprocess.CalledProcessError, OSError):

--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -2,6 +2,7 @@
 
 import os
 import struct
+import subprocess
 from bisect import insort_left
 from pathlib import Path
 from typing import BinaryIO, Optional
@@ -28,6 +29,12 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                     with open(self._dir + f.name, "rb") as rf:
                         rf.seek(offset or 0)
                         return rf.read(read_len)
+            # Yamcs needs a filename that does not comply with the oresat filename schema.
+            # We will as a fallback look for .dirlist* after failing to find a normal file.
+            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
+                with open(self._dir + file.name, "rb") as rf:
+                    rf.seek(offset or 0)
+                    return rf.read(read_len)
             raise FileNotFoundError(file)
 
     def file_size(self, file: Path) -> int:
@@ -47,7 +54,10 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
 
     def file_exists(self, path: Path) -> bool:
         with self._lock:
-            return any(path.name == f.name for f in self._data)
+            return (
+                any(path.name == f.name for f in self._data)
+                or (".dirlist" in path.name and (Path(self._dir) / path).exists())
+            )
 
     def stat(self, file: Path) -> os.stat_result:
         """Implements os.stat() but for a filestore
@@ -61,6 +71,8 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
             for f in self._data:
                 if file.name == f.name:
                     return Path(self._dir, f.name).stat()
+            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
+                return Path(self._dir, file.name).stat()
             raise FileNotFoundError(file)
 
     def truncate_file(self, file: Path) -> None:
@@ -69,6 +81,9 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                 if file.name == f.name:
                     with open(self._dir + f.name, "w"):
                         return
+            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
+                with open(self._dir + file.name, "w"):
+                    return
             raise FileNotFoundError(file)
 
     def write_data(self, file: Path, data: bytes, offset: Optional[int] = None) -> None:
@@ -106,6 +121,9 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
                     os.remove(self._dir + f.name)
                     self._data.remove(f)
                     return FilestoreResult.DELETE_SUCCESS
+            if ".dirlist" in file.name and (Path(self._dir) / file).exists():
+                os.remove(self._dir + file.name)
+                return FilestoreResult.DELETE_SUCCESS
             return FilestoreResult.DELETE_FILE_DOES_NOT_EXIST
 
     def rename_file(self, old_file: Path, new_file: Path) -> FilestoreResult:
@@ -148,18 +166,16 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
     def list_directory(
         self, _dir_name: Path, file_name: Path, recursive: bool = False
     ) -> FilestoreResult:
-        # dir_name is ignored, there are no directories to be considered
-        try:
-            listing = OreSatFile(file_name.name)
-        except ValueError:
-            return FilestoreResult.NOT_PERFORMED
-
-        with self._lock, open(self._dir + file_name.name, "w") as f:
-            insort_left(self._data, listing)
-            # Explicitly not reading from self._data here to help report invalid states
-            for line in os.walk(self._dir) if recursive else os.listdir(self._dir):
-                f.write(f"{line}\n")
-            return FilestoreResult.SUCCESS
+        cmd = ["ls", "-al"]
+        fullpath = Path(self._dir) / file_name
+        with open(fullpath, "w") as of:
+            of.write(f"Contents of directory {_dir_name} generated with '{cmd}':\n")
+            try:
+                result = subprocess.run(cmd, check=True, capture_output=True, cwd=self._dir)
+            except (subprocess.CalledProcessError, OSError):
+                return FilestoreResult.NOT_PERFORMED
+            of.write(result.stdout.decode())
+        return FilestoreResult.SUCCESS
 
     def calc_modular_checksum(self, file_path: Path) -> bytes:
         """Calculates the modular checksum of the file in file_path.

--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -56,7 +56,7 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
         with self._lock:
             return (
                 any(path.name == f.name for f in self._data)
-                or (".dirlist" in path.name and (Path(self._dir) / path).exists())
+                or (Path(self._dir) / path).exists()
             )
 
     def stat(self, file: Path) -> os.stat_result:
@@ -166,9 +166,6 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
     def list_directory(
         self, _dir_name: Path, file_name: Path, recursive: bool = False
     ) -> FilestoreResult:
-        if not _dir_name.exists() or not _dir_name.is_dir():
-            return FilestoreResult.NOT_PERFORMED
-
         cmd = ["ls", "-al"]
         fullpath = Path(self._dir) / file_name
         with open(fullpath, "w") as of:

--- a/oresat_c3/protocols/cachestore.py
+++ b/oresat_c3/protocols/cachestore.py
@@ -48,7 +48,7 @@ class CacheStore(VirtualFilestore, OreSatFileCache):
 
     def file_exists(self, path: Path) -> bool:
         with self._lock:
-            return (any(path.name == f.name for f in self._data))
+            return any(path.name == f.name for f in self._data)
 
     def stat(self, file: Path) -> os.stat_result:
         """Implements os.stat() but for a filestore

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -283,7 +283,7 @@ class CfdpUser(CfdpUserBase):
             put_req = PutRequest(
                 destination_id=put_req_params.dest_entity_id,
                 source_file=Path(put_req_params.source_file_as_path),
-                dest_file=Path(put_req_params.dest_file_as_path), # Don't really understand why this needs a path. TODO: understand and fix.
+                dest_file=Path(put_req_params.dest_file_as_path),
                 trans_mode=None,
                 closure_requested=None,
                 msgs_to_user=[
@@ -355,7 +355,7 @@ class CustomCheckTimerProvider(CheckTimerProvider):
 
 
 class SourceEntityHandler(Thread):
-    BASE_STR_SRC = "Source:"
+    BASE_STR_SRC = "Source id"
 
     def __init__(
         self,
@@ -369,10 +369,14 @@ class SourceEntityHandler(Thread):
     ):
         super().__init__()
         src_seq_count_provider = SeqCountProvider(16)
-        src_user = CfdpUser(self.BASE_STR_SRC, put_req_queue)
+        src_user = CfdpUser(self.BASE_STR_SRC + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
         self.source_handler = VfsSourceHandler(
-            cfg=LocalEntityConfig(sat_id, IndicationConfig(), CfdpFaultHandler(self.BASE_STR_SRC)),
+            cfg=LocalEntityConfig(
+                sat_id,
+                IndicationConfig(),
+                CfdpFaultHandler(self.BASE_STR_SRC + sat_id.__str__())
+            ),
             seq_num_provider=src_seq_count_provider,
             remote_cfg_table=remote_entities,
             user=src_user,
@@ -447,8 +451,7 @@ class SourceEntityHandler(Thread):
             while fsm_result.states.num_packets_ready > 0:
                 next_pdu_wrapper = self.source_handler.get_next_packet()
                 assert next_pdu_wrapper is not None
-                if self.verbose_level >= 1:
-                    logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
+                logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
                 # Send all packets which need to be sent.
                 self.tm_queue.put(next_pdu_wrapper.pack())
                 packet_sent = True
@@ -458,16 +461,17 @@ class SourceEntityHandler(Thread):
         logger.info("Starting Source Entity Handler")
         while True:
             if self.stop_signal.is_set():
+                logger.info(f"Stopping Source Entity Handler. Local ID {self.sat_id}")
                 break
             if self.source_handler.state == CfdpState.IDLE and not self._idle_handling():
-                time.sleep(0.2)
+                time.sleep(0.1)
                 continue
             if self.source_handler.state == CfdpState.BUSY and not self._busy_handling():
-                time.sleep(0.2)
+                time.sleep(0.1)
 
 
 class DestEntityHandler(Thread):
-    BASE_STR_DEST = "Dest:"
+    BASE_STR_DEST = "Dest id"
 
     def __init__(
         self,
@@ -480,10 +484,14 @@ class DestEntityHandler(Thread):
     ):
         super().__init__()
 
-        dest_user = CfdpUser(self.BASE_STR_DEST, put_req_queue)
+        dest_user = CfdpUser(self.BASE_STR_DEST + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
-        self.sdest_handler = DestHandler(
-            cfg=LocalEntityConfig(sat_id, IndicationConfig(), CfdpFaultHandler(self.BASE_STR_DEST)),
+        self.dest_handler = DestHandler(
+            cfg=LocalEntityConfig(
+                sat_id,
+                IndicationConfig(),
+                CfdpFaultHandler(self.BASE_STR_DEST + sat_id.__str__())
+            ),
             user=dest_user,
             remote_cfg_table=remote_entities,
             check_timer_provider=check_timer_provider,
@@ -500,6 +508,7 @@ class DestEntityHandler(Thread):
             packet_received = False
             packet = None
             if self.stop_signal.is_set():
+                logger.info(f"Stopping Dest Entity Handler. Local ID {self.sat_id}")
                 break
             try:
                 packet = self.dest_entity_queue.get(False)
@@ -514,8 +523,7 @@ class DestEntityHandler(Thread):
                 while fsm_result.states.num_packets_ready > 0:
                     next_pdu_wrapper = self.dest_handler.get_next_packet()
                     assert next_pdu_wrapper is not None
-                    if self.verbose_level >= 1:
-                        logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
+                    logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
                     self.tm_queue.put(next_pdu_wrapper.pack())
                     packet_sent = True
             # If there is no work to do, put the thread to sleep.

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -20,6 +20,7 @@ from cfdppy.exceptions import (
     PduIgnoredForSource,
     SourceFileDoesNotExist,
 )
+from cfdppy.filestore import FilestoreResult
 from cfdppy.handler.dest import CompletionDisposition, DestHandler
 from cfdppy.handler.dest import TransactionStep as DestTransactionStep
 from cfdppy.handler.source import SourceHandler
@@ -57,7 +58,6 @@ from spacepackets.cfdp.pdu import (
 )
 from spacepackets.cfdp.pdu.file_data import FileDataParams
 from spacepackets.cfdp.tlv import (
-    DirectoryListingResponse,
     DirectoryOperationMessageType,
     MessageToUserTlv,
     OriginatingTransactionId,
@@ -444,7 +444,20 @@ class CfdpUser(CfdpUserBase):
         ) -> None:
         params = reserved_cfdp_msg.get_dir_listing_request_params()
         if reserved_cfdp_msg.get_directory_operation_type() == DirectoryOperationMessageType.LISTING_REQUEST:  # noqa: E501
-            resp = self.vfs.list_directory(params.dir_path_as_path, params.dir_file_name_as_path, False)
+            resp = self.vfs.list_directory(
+                params.dir_path_as_path,
+                params.dir_file_name_as_path,
+                False
+            )
+            # FIXME: This fixes an issue with DirectoryListingResponse spacepackets <= 0.31.0.
+            # Remove this once we are on 0.32.0
+            value = (
+                bytes([0x00 if resp == FilestoreResult.SUCCESS else 0x80])
+                + params.dir_path.pack()
+                + params.dir_file_name.pack()
+            )
+            mtu_response = ReservedCfdpMessage(DirectoryOperationMessageType.LISTING_RESPONSE,value)
+
             put_req = PutRequest(
                 destination_id=transaction_id.source_id,
                 source_file=params.dir_file_name_as_path,
@@ -452,10 +465,7 @@ class CfdpUser(CfdpUserBase):
                 trans_mode=None,
                 closure_requested=True,
                 msgs_to_user=[
-                    DirectoryListingResponse(
-                        listing_success=False,
-                        dir_params=params,
-                    ).to_generic_msg_to_user_tlv(),
+                    mtu_response.to_generic_msg_to_user_tlv(),
                     OriginatingTransactionId(transaction_id).to_generic_msg_to_user_tlv(),
                 ],
             )

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from queue import Empty, SimpleQueue
 from threading import Event, Thread
 
-from cfdppy import CfdpState, PacketDestination, get_packet_destination
+from cfdppy import CfdpState
 from cfdppy.exceptions import (
     InvalidDestinationId,
     NoRemoteEntityConfigFound,
@@ -26,7 +26,6 @@ from cfdppy.mib import (
     EntityType,
     IndicationConfig,
     LocalEntityConfig,
-    RemoteEntityConfig,
     RemoteEntityConfigTable,
 )
 from cfdppy.request import PutRequest
@@ -39,14 +38,11 @@ from cfdppy.user import (
 )
 from olaf import logger
 from spacepackets.cfdp import (
-    ChecksumType,
     ConditionCode,
-    FaultHandlerCode,
     PduHolder,
-    PduType,
     TransmissionMode,
 )
-from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
+from spacepackets.cfdp.defs import DeliveryCode, TransactionId
 from spacepackets.cfdp.pdu import (
     AbstractFileDirectiveBase,
     DirectiveType,

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -16,7 +16,7 @@ from cfdppy.exceptions import (
     SourceFileDoesNotExist,
 )
 from cfdppy.handler.dest import CompletionDisposition, DestHandler
-from cfdppy.handler.source import SourceHandler
+from cfdppy.handler.source import SourceHandler, TransactionStep
 from cfdppy.mib import (
     CheckTimerProvider,
     DefaultFaultHandlerBase,
@@ -43,7 +43,7 @@ from spacepackets.cfdp import (
     TransmissionMode,
 )
 from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
-from spacepackets.cfdp.pdu import AbstractFileDirectiveBase, EofPdu, FileDataPdu
+from spacepackets.cfdp.pdu import AbstractFileDirectiveBase, DirectiveType, EofPdu, FileDataPdu
 from spacepackets.cfdp.pdu.file_data import FileDataParams
 from spacepackets.cfdp.tlv import (
     DirectoryListingResponse,
@@ -94,6 +94,37 @@ class VfsSourceHandler(SourceHandler):
         fd_params = FileDataParams(file_data=file_data, offset=offset, segment_metadata=None)
         file_data_pdu = FileDataPdu(pdu_conf=self._params.pdu_conf, params=fd_params)
         self._add_packet_to_be_sent(file_data_pdu)
+
+    def _sending_file_data_fsm(self, packet_holder: PduHolder) -> bool:
+        """Fixes the parent not sending EOFs for metadata only transactions. CCSDS 720.1-G-4 and
+        YAMCS both have proxy put requests sending EOFs, so this brings cfdppy into compliance.
+        """
+        logger.warning("do we get here?")
+        if self.transmission_mode == TransmissionMode.ACKNOWLEDGED and super()._SourceHandler__handle_retransmission(
+            packet_holder
+        ):
+            logger.warning("do we get here?fail")
+            return True
+        logger.warning("do we get here?2")
+        # No need to send a file data PDU for an empty file
+        if (
+            not self._params.fp.metadata_only
+            and self._params.fp.progress < self._params.fp.file_size
+        ):
+            logger.warning("do we get here?what")
+            self._prepare_progressing_file_data_pdu()
+            # Not finished yet. We exit here to allow the user to do flow control.
+            return True
+        logger.warning("do we get here?3")
+        if self._params.fp.empty_file or self._params.fp.metadata_only:
+            self._params.cond_code_eof = ConditionCode.NO_ERROR
+            self.states.step = TransactionStep.SENDING_EOF
+        return False
+
+    def _checksum_calculation(self, size_to_calculate: int) -> bytes:
+        if self._params.fp.metadata_only:
+            return b'\0' * 4
+        return super()._checksum_calculation(size_to_calculate)
 
 
 class FixedDestHandler(DestHandler):

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -16,7 +16,9 @@ from cfdppy.exceptions import (
     SourceFileDoesNotExist,
 )
 from cfdppy.handler.dest import CompletionDisposition, DestHandler
-from cfdppy.handler.source import SourceHandler, TransactionStep
+from cfdppy.handler.dest import TransactionStep as DestTransactionStep
+from cfdppy.handler.source import SourceHandler
+from cfdppy.handler.source import TransactionStep as SrcTransactionStep
 from cfdppy.mib import (
     CheckTimerProvider,
     DefaultFaultHandlerBase,
@@ -43,7 +45,13 @@ from spacepackets.cfdp import (
     TransmissionMode,
 )
 from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
-from spacepackets.cfdp.pdu import AbstractFileDirectiveBase, DirectiveType, EofPdu, FileDataPdu
+from spacepackets.cfdp.pdu import (
+    AbstractFileDirectiveBase,
+    DirectiveType,
+    EofPdu,
+    FileDataPdu,
+    MetadataPdu,
+)
 from spacepackets.cfdp.pdu.file_data import FileDataParams
 from spacepackets.cfdp.tlv import (
     DirectoryListingResponse,
@@ -54,6 +62,7 @@ from spacepackets.cfdp.tlv import (
     ProxyPutResponse,
     ProxyPutResponseParams,
     ReservedCfdpMessage,
+    TlvType,
 )
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
@@ -99,26 +108,21 @@ class VfsSourceHandler(SourceHandler):
         """Fixes the parent not sending EOFs for metadata only transactions. CCSDS 720.1-G-4 and
         YAMCS both have proxy put requests sending EOFs, so this brings cfdppy into compliance.
         """
-        logger.warning("do we get here?")
         if self.transmission_mode == TransmissionMode.ACKNOWLEDGED and super()._SourceHandler__handle_retransmission(
             packet_holder
         ):
-            logger.warning("do we get here?fail")
             return True
-        logger.warning("do we get here?2")
         # No need to send a file data PDU for an empty file
         if (
             not self._params.fp.metadata_only
             and self._params.fp.progress < self._params.fp.file_size
         ):
-            logger.warning("do we get here?what")
             self._prepare_progressing_file_data_pdu()
             # Not finished yet. We exit here to allow the user to do flow control.
             return True
-        logger.warning("do we get here?3")
         if self._params.fp.empty_file or self._params.fp.metadata_only:
             self._params.cond_code_eof = ConditionCode.NO_ERROR
-            self.states.step = TransactionStep.SENDING_EOF
+            self.states.step = SrcTransactionStep.SENDING_EOF
         return False
 
     def _checksum_calculation(self, size_to_calculate: int) -> bytes:
@@ -176,6 +180,51 @@ class FixedDestHandler(DestHandler):
         """Same issue as _handle_eof_pdu"""
         eof_pdu.condition_code >>= 4
         return super()._handle_eof_without_previous_metadata(eof_pdu)
+
+    def _handle_metadata_packet(self, metadata_pdu: MetadataPdu) -> None:
+        """Fixes the desthandler ending as soon as a proxy put request Metadata PDU is received."""
+        assert self._params.transaction_id is not None
+        self._params.checksum_type = metadata_pdu.checksum_type
+        self._params.closure_requested = metadata_pdu.closure_requested
+        self._params.acked_params.metadata_missing = False
+        if metadata_pdu.dest_file_name is None or metadata_pdu.source_file_name is None:
+            self._params.fp.metadata_only = True
+            self._params.finished_params.delivery_code = DeliveryCode.DATA_COMPLETE
+        else:
+            self._params.fp.file_name = Path(metadata_pdu.dest_file_name)
+        self._params.fp.file_size = metadata_pdu.file_size
+        # To be fully standard-compliant or at least allow the flexibility to be standard-compliant
+        # in the future, we should require that a remote entity configuration exists for each CFDP
+        # sender.
+        if self._params.remote_cfg is None:
+            logger.warning(
+                f"No remote configuration found for remote ID {metadata_pdu.dest_entity_id}"
+            )
+            raise NoRemoteEntityConfigFound(metadata_pdu.dest_entity_id)
+        self.states.step = DestTransactionStep.RECEIVING_FILE_DATA
+        logger.warning("do we get here?")
+        if not self._params.fp.metadata_only:
+            assert metadata_pdu.source_file_name is not None
+            self._init_vfs_handling(Path(metadata_pdu.source_file_name).name)
+        msgs_to_user_list: None | list[MessageToUserTlv] = None
+        options = metadata_pdu.options_as_tlv()
+        if options is not None:
+            msgs_to_user_list = []
+            for tlv in options:
+                if tlv.tlv_type == TlvType.MESSAGE_TO_USER:
+                    msgs_to_user_list.append(MessageToUserTlv.from_tlv(tlv))
+        file_size_for_indication = (
+            None if metadata_pdu.source_file_name is None else metadata_pdu.file_size
+        )
+        params = MetadataRecvParams(
+            transaction_id=self._params.transaction_id,
+            file_size=file_size_for_indication,
+            source_id=metadata_pdu.source_entity_id,
+            dest_file_name=metadata_pdu.dest_file_name,
+            source_file_name=metadata_pdu.source_file_name,
+            msgs_to_user=msgs_to_user_list,
+        )
+        self.user.metadata_recv_indication(params)
 
 
 class CfdpFaultHandler(DefaultFaultHandlerBase):
@@ -468,7 +517,7 @@ class SourceEntityHandler(Thread):
         """Returns whether a packet was sent."""
 
         if packet is not None:
-            logger.debug(f"=Inserting {packet}")
+            logger.debug(f"Source received {packet}")
         try:
             fsm_result = self.source_handler.state_machine(packet)
         except InvalidDestinationId as e:
@@ -495,7 +544,7 @@ class SourceEntityHandler(Thread):
                 logger.info(f"Stopping Source Entity Handler. Local ID {self.sat_id}")
                 break
             if self.source_handler.state == CfdpState.IDLE and not self._idle_handling():
-                time.sleep(0.2)
+                time.sleep(1)
                 continue
             if self.source_handler.state == CfdpState.BUSY and not self._busy_handling():
                 time.sleep(0.1)
@@ -517,7 +566,7 @@ class DestEntityHandler(Thread):
 
         dest_user = CfdpUser(self.BASE_STR_DEST + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
-        self.dest_handler = DestHandler(
+        self.dest_handler = FixedDestHandler(
             cfg=LocalEntityConfig(
                 sat_id,
                 IndicationConfig(),
@@ -547,7 +596,7 @@ class DestEntityHandler(Thread):
             except Empty:
                 pass
             if packet is not None:
-                logger.debug(f"Inserting {packet}")
+                logger.debug(f"Dest received {packet}")
             fsm_result = self.dest_handler.state_machine(packet)
             packet_sent = False
             if fsm_result.states.num_packets_ready > 0:
@@ -559,5 +608,5 @@ class DestEntityHandler(Thread):
                     packet_sent = True
             # If there is no work to do, put the thread to sleep.
             if not packet_received and not packet_sent:
-                time.sleep(0.5)
+                time.sleep(0.1)
 

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -464,7 +464,7 @@ class SourceEntityHandler(Thread):
                 logger.info(f"Stopping Source Entity Handler. Local ID {self.sat_id}")
                 break
             if self.source_handler.state == CfdpState.IDLE and not self._idle_handling():
-                time.sleep(0.1)
+                time.sleep(0.2)
                 continue
             if self.source_handler.state == CfdpState.BUSY and not self._busy_handling():
                 time.sleep(0.1)

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -4,6 +4,7 @@ Most or all of these changes should eventually be submitted upstream.
 """
 
 import time
+from datetime import timedelta
 from pathlib import Path
 from queue import Empty, SimpleQueue
 from threading import Event, Thread
@@ -54,6 +55,8 @@ from spacepackets.cfdp.tlv import (
     ProxyPutResponseParams,
     ReservedCfdpMessage,
 )
+from spacepackets.countdown import Countdown
+from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
 
 
@@ -142,6 +145,42 @@ class FixedDestHandler(DestHandler):
         """Same issue as _handle_eof_pdu"""
         eof_pdu.condition_code >>= 4
         return super()._handle_eof_without_previous_metadata(eof_pdu)
+
+
+class CfdpFaultHandler(DefaultFaultHandlerBase):
+    def __init__(self, base_str: str):
+        self.base_str = base_str
+        super().__init__()
+
+    def notice_of_suspension_cb(
+        self, transaction_id: TransactionId, cond: ConditionCode, progress: int
+    ) -> None:
+        logger.warning(
+            f"{self.base_str}: Received Notice of Suspension for transaction {transaction_id!r} "
+            f"with condition code {cond!r}. Progress: {progress}"
+        )
+
+    def notice_of_cancellation_cb(
+        self, transaction_id: TransactionId, cond: ConditionCode, progress: int
+    ) -> None:
+        logger.warning(
+            f"{self.base_str}: Received Notice of Cancellation for transaction {transaction_id!r} "
+            f"with condition code {cond!r}. Progress: {progress}"
+        )
+
+    def abandoned_cb(
+        self, transaction_id: TransactionId, cond: ConditionCode, progress: int
+    ) -> None:
+        logger.warning(
+            f"{self.base_str}: Abandoned fault for transaction {transaction_id!r} "
+            f"with condition code {cond!r}. Progress: {progress}"
+        )
+
+    def ignore_cb(self, transaction_id: TransactionId, cond: ConditionCode, progress: int) -> None:
+        logger.warning(
+            f"{self.base_str}: Ignored fault for transaction {transaction_id!r} "
+            f"with condition code {cond!r}. Progress: {progress}"
+        )
 
 
 class CfdpUser(CfdpUserBase):
@@ -303,41 +342,58 @@ class CfdpUser(CfdpUserBase):
     def eof_recv_indication(self, transaction_id: TransactionId) -> None:
         logger.info(f"{self.base_str}: EOF-Recv.indication for {transaction_id}")
 
+
 # Don't know what this is for yet. TODO: figure that out.
-# class CustomCheckTimerProvider(CheckTimerProvider):
-#     def provide_check_timer(
-#         self,
-#         local_entity_id: ByteFieldU8,
-#         remote_entity_id: ByteFieldU8,
-#         entity_type: EntityType,
-#     ) -> Countdown:
-#         return Countdown(timedelta(seconds=5.0))
+class CustomCheckTimerProvider(CheckTimerProvider):
+    def provide_check_timer(
+        self,
+        local_entity_id: ByteFieldU8,
+        remote_entity_id: ByteFieldU8,
+        entity_type: EntityType,
+    ) -> Countdown:
+        return Countdown(timedelta(seconds=5.0))
 
 
 class SourceEntityHandler(Thread):
+    BASE_STR_SRC = "Source:"
+
     def __init__(
         self,
-        source_handler: SourceHandler,
         put_req_queue: SimpleQueue,
         source_entity_queue: SimpleQueue,
         tm_queue: SimpleQueue,
+        remote_entities: RemoteEntityConfigTable,
+        gnd_id: ByteFieldU8,
+        sat_id: ByteFieldU8,
         stop_signal: Event,
     ):
         super().__init__()
-        self.source_handler = source_handler
+        src_seq_count_provider = SeqCountProvider(16)
+        src_user = CfdpUser(self.BASE_STR_SRC, put_req_queue)
+        check_timer_provider = CustomCheckTimerProvider()
+        self.source_handler = VfsSourceHandler(
+            cfg=LocalEntityConfig(sat_id, IndicationConfig(), CfdpFaultHandler(self.BASE_STR_SRC)),
+            seq_num_provider=src_seq_count_provider,
+            remote_cfg_table=remote_entities,
+            user=src_user,
+            check_timer_provider=check_timer_provider,
+        )
+
         self.put_req_queue = put_req_queue
         self.source_entity_queue = source_entity_queue
         self.tm_queue = tm_queue
+        self.gnd_id = gnd_id
+        self.sat_id = sat_id
         self.stop_signal = stop_signal
 
     def _idle_handling(self) -> bool:
         try:
             put_req: PutRequest = self.put_req_queue.get(False)
             logger.info(f"Handling Put Request: {put_req}")
-            if put_req.destination_id not in [LOCAL_ENTITY_ID, REMOTE_ENTITY_ID]:
+            if put_req.destination_id not in [self.sat_id, self.gnd_id]:
                 logger.warning(
-                    f"can only handle put requests target towards {REMOTE_ENTITY_ID} or "
-                    f"{LOCAL_ENTITY_ID}" # These were global variables. TODO: fix
+                    f"can only handle put requests target towards {self.gnd_id} or "
+                    f"{self.sat_id}"
                 )
 
             else:
@@ -411,21 +467,35 @@ class SourceEntityHandler(Thread):
 
 
 class DestEntityHandler(Thread):
+    BASE_STR_DEST = "Dest:"
+
     def __init__(
         self,
-        dest_handler: DestHandler,
+        put_req_queue: SimpleQueue,
         dest_entity_queue: SimpleQueue,
         tm_queue: SimpleQueue,
+        remote_entities: RemoteEntityConfigTable,
+        sat_id: ByteFieldU8,
         stop_signal: Event,
     ):
         super().__init__()
-        self.dest_handler = dest_handler
+
+        dest_user = CfdpUser(self.BASE_STR_DEST, put_req_queue)
+        check_timer_provider = CustomCheckTimerProvider()
+        self.sdest_handler = DestHandler(
+            cfg=LocalEntityConfig(sat_id, IndicationConfig(), CfdpFaultHandler(self.BASE_STR_DEST)),
+            user=dest_user,
+            remote_cfg_table=remote_entities,
+            check_timer_provider=check_timer_provider,
+        )
+
         self.dest_entity_queue = dest_entity_queue
         self.tm_queue = tm_queue
+        self.sat_id = sat_id
         self.stop_signal = stop_signal
 
     def run(self) -> None:
-        logger.info(f"Starting Dest Entity Handler. Local ID {self.dest_handler.cfg.local_entity_id}")
+        logger.info(f"Starting Dest Entity Handler. Local ID {self.sat_id}")
         while True:
             packet_received = False
             packet = None

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -13,6 +13,7 @@ from cfdppy import CfdpState, PacketDestination, get_packet_destination
 from cfdppy.exceptions import (
     InvalidDestinationId,
     NoRemoteEntityConfigFound,
+    PduIgnoredForSource,
     SourceFileDoesNotExist,
 )
 from cfdppy.handler.dest import CompletionDisposition, DestHandler
@@ -42,6 +43,7 @@ from spacepackets.cfdp import (
     ConditionCode,
     FaultHandlerCode,
     PduHolder,
+    PduType,
     TransmissionMode,
 )
 from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
@@ -200,6 +202,15 @@ class FixedDestHandler(DestHandler):
         """Same issue as _handle_eof_pdu"""
         eof_pdu.condition_code >>= 4
         return super()._handle_eof_without_previous_metadata(eof_pdu)
+
+    def _handle_waiting_for_finished_ack(self, packet_holder: PduHolder) -> None:
+        # For some reason the upstream package will not re-send the EOF_ACK if it gets dropped.
+        if (
+            packet_holder.pdu is not None
+            and packet_holder.pdu_directive_type == DirectiveType.EOF_PDU
+        ):
+            self._handle_eof_pdu(packet_holder.pdu)
+        super()._handle_waiting_for_finished_ack(packet_holder)
 
     def _handle_metadata_packet(self, metadata_pdu: MetadataPdu) -> None:
         """Fixes the desthandler ending as soon as a proxy put request Metadata PDU is received."""
@@ -572,6 +583,9 @@ class SourceEntityHandler(Thread):
                 f"invalid destination ID {e.found_dest_id} on packet {packet}, expected "
                 f"{e.expected_dest_id}"
             )
+            fsm_result = self.source_handler.state_machine(None)
+        except PduIgnoredForSource as e:
+            logger.warning(f"Ignoring PDU: {e.reason}")
             fsm_result = self.source_handler.state_machine(None)
         packet_sent = False
         if fsm_result.states.num_packets_ready > 0:

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -40,6 +40,7 @@ from cfdppy.user import (
 from olaf import logger
 from spacepackets.cfdp import (
     ConditionCode,
+    FaultHandlerCode,
     PduHolder,
     TransmissionMode,
 )
@@ -257,6 +258,32 @@ class FixedDestHandler(DestHandler):
             msgs_to_user=msgs_to_user_list,
         )
         self.user.metadata_recv_indication(params)
+
+    def _declare_fault(self, cond: ConditionCode) -> FaultHandlerCode:
+        """
+        As far as I can tell abandon transaction is never called, so the dest handler endlessly
+        tries to cancel transactions without ever actually ending them.
+        """
+        fh = self.cfg.default_fault_handlers.get_fault_handler(cond)
+        transaction_id = self._params.transaction_id
+        progress = self._params.fp.progress
+        assert transaction_id is not None
+        if fh is None:
+            raise ValueError(f"invalid condition code {cond!r} for fault declaration")
+        if fh == FaultHandlerCode.NOTICE_OF_CANCELLATION:
+            if ( # If we've already cancelled, abandon instead
+                self._params.completion_disposition == CompletionDisposition.CANCELED
+            ):
+                fh = FaultHandlerCode.ABANDON_TRANSACTION
+                self._abandon_transaction()
+            else:
+                self._notice_of_cancellation(cond)
+        elif fh == FaultHandlerCode.NOTICE_OF_SUSPENSION:
+            self._notice_of_suspension()
+        elif fh == FaultHandlerCode.ABANDON_TRANSACTION:
+            self._abandon_transaction()
+        self.cfg.default_fault_handlers.report_fault(transaction_id, cond, progress)
+        return fh
 
 
 class CfdpFaultHandler(DefaultFaultHandlerBase):

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -3,6 +3,9 @@
 Most or all of these changes should eventually be submitted upstream.
 """
 
+# FIXME: Lets this file pass py3.9 tests. Remove when tests use 3.12
+from __future__ import annotations
+
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -441,7 +444,7 @@ class CfdpUser(CfdpUserBase):
         ) -> None:
         params = reserved_cfdp_msg.get_dir_listing_request_params()
         if reserved_cfdp_msg.get_directory_operation_type() == DirectoryOperationMessageType.LISTING_REQUEST:  # noqa: E501
-            self.vfs.list_directory(params.dir_path_as_path, params.dir_file_name_as_path, False)
+            resp = self.vfs.list_directory(params.dir_path_as_path, params.dir_file_name_as_path, False)
             put_req = PutRequest(
                 destination_id=transaction_id.source_id,
                 source_file=params.dir_file_name_as_path,
@@ -450,7 +453,7 @@ class CfdpUser(CfdpUserBase):
                 closure_requested=True,
                 msgs_to_user=[
                     DirectoryListingResponse(
-                        listing_success=True,
+                        listing_success=False,
                         dir_params=params,
                     ).to_generic_msg_to_user_tlv(),
                     OriginatingTransactionId(transaction_id).to_generic_msg_to_user_tlv(),

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -278,7 +278,7 @@ class FixedDestHandler(DestHandler):
         if fh is None:
             raise ValueError(f"invalid condition code {cond!r} for fault declaration")
         if fh == FaultHandlerCode.NOTICE_OF_CANCELLATION:
-            if ( # If we've already cancelled, abandon instead
+            if (  # If we've already cancelled, abandon instead
                 self._params.completion_disposition == CompletionDisposition.CANCELED
             ):
                 fh = FaultHandlerCode.ABANDON_TRANSACTION
@@ -446,15 +446,15 @@ class CfdpUser(CfdpUserBase):
             logger.info(f"Received Proxy Put Response: {put_response_params}")
 
     def _handle_directory_operation(
-            self, transaction_id: TransactionId, reserved_cfdp_msg: ReservedCfdpMessage
-        ) -> None:
+        self, transaction_id: TransactionId, reserved_cfdp_msg: ReservedCfdpMessage
+    ) -> None:
         params = reserved_cfdp_msg.get_dir_listing_request_params()
-        if (reserved_cfdp_msg.get_directory_operation_type()
-            == DirectoryOperationMessageType.LISTING_REQUEST):
+        if (
+            reserved_cfdp_msg.get_directory_operation_type()
+            == DirectoryOperationMessageType.LISTING_REQUEST
+        ):
             resp = self.vfs.list_directory(
-                params.dir_path_as_path,
-                self.DIRECTORY_LISTING_FILE,
-                False
+                params.dir_path_as_path, self.DIRECTORY_LISTING_FILE, False
             )
             # FIXME: This fixes an issue with DirectoryListingResponse spacepackets <= 0.31.0.
             # Remove this once we are on 0.32.0
@@ -463,7 +463,9 @@ class CfdpUser(CfdpUserBase):
                 + params.dir_path.pack()
                 + params.dir_file_name.pack()
             )
-            mtu_response = ReservedCfdpMessage(DirectoryOperationMessageType.LISTING_RESPONSE,value)
+            mtu_response = ReservedCfdpMessage(
+                DirectoryOperationMessageType.LISTING_RESPONSE, value
+            )
 
             put_req = PutRequest(
                 destination_id=transaction_id.source_id,
@@ -477,8 +479,10 @@ class CfdpUser(CfdpUserBase):
                 ],
             )
             self.put_req_queue.put(put_req)
-        elif (reserved_cfdp_msg.get_directory_operation_type()
-            == DirectoryOperationMessageType.LISTING_RESPONSE):
+        elif (
+            reserved_cfdp_msg.get_directory_operation_type()
+            == DirectoryOperationMessageType.LISTING_RESPONSE
+        ):
             dir_list_response_params = reserved_cfdp_msg.get_dir_listing_response_params()
             logger.info(f"Received Directory Listing Response: {dir_list_response_params}")
 
@@ -560,9 +564,7 @@ class SourceEntityHandler(Thread):
         check_timer_provider = CustomCheckTimerProvider()
         self.source_handler = VfsSourceHandler(
             cfg=LocalEntityConfig(
-                sat_id,
-                IndicationConfig(),
-                CfdpFaultHandler(self.BASE_STR_SRC + sat_id.__str__())
+                sat_id, IndicationConfig(), CfdpFaultHandler(self.BASE_STR_SRC + sat_id.__str__())
             ),
             seq_num_provider=src_seq_count_provider,
             remote_cfg_table=remote_entities,
@@ -583,8 +585,7 @@ class SourceEntityHandler(Thread):
             logger.info(f"Handling Put Request: {put_req}")
             if put_req.destination_id not in [self.sat_id, self.gnd_id]:
                 logger.warning(
-                    f"can only handle put requests target towards {self.gnd_id} or "
-                    f"{self.sat_id}"
+                    f"can only handle put requests target towards {self.gnd_id} or {self.sat_id}"
                 )
 
             else:
@@ -685,9 +686,7 @@ class DestEntityHandler(Thread):
         check_timer_provider = CustomCheckTimerProvider()
         self.dest_handler = FixedDestHandler(
             cfg=LocalEntityConfig(
-                sat_id,
-                IndicationConfig(),
-                CfdpFaultHandler(self.BASE_STR_DEST + sat_id.__str__())
+                sat_id, IndicationConfig(), CfdpFaultHandler(self.BASE_STR_DEST + sat_id.__str__())
             ),
             user=dest_user,
             remote_cfg_table=remote_entities,
@@ -729,4 +728,3 @@ class DestEntityHandler(Thread):
             # If there is no work to do, put the thread to sleep.
             if not packet_received and not packet_sent:
                 time.sleep(0.1)
-

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -364,6 +364,8 @@ class CfdpUser(CfdpUserBase):
     ) -> None:
         if reserved_cfdp_msg.is_cfdp_proxy_operation():
             self._handle_cfdp_proxy_operation(transaction_id, reserved_cfdp_msg)
+        elif reserved_cfdp_msg.is_directory_operation():
+            self._handle_directory_operation(transaction_id, reserved_cfdp_msg)
         elif reserved_cfdp_msg.is_originating_transaction_id():
             logger.info(
                 f"Received originating transaction ID: "
@@ -391,6 +393,31 @@ class CfdpUser(CfdpUserBase):
         elif reserved_cfdp_msg.get_cfdp_proxy_message_type() == ProxyMessageType.PUT_RESPONSE:
             put_response_params = reserved_cfdp_msg.get_proxy_put_response_params()
             logger.info(f"Received Proxy Put Response: {put_response_params}")
+
+    def _handle_directory_operation(
+            self, transaction_id: TransactionId, reserved_cfdp_msg: ReservedCfdpMessage
+        ) -> None:
+        params = reserved_cfdp_msg.get_dir_listing_request_params()
+        if reserved_cfdp_msg.get_directory_operation_type() == DirectoryOperationMessageType.LISTING_REQUEST:  # noqa: E501
+            self.vfs.list_directory(params.dir_path_as_path, params.dir_file_name_as_path, False)
+            put_req = PutRequest(
+                destination_id=transaction_id.source_id,
+                source_file=params.dir_file_name_as_path,
+                dest_file=params.dir_file_name_as_path,
+                trans_mode=None,
+                closure_requested=True,
+                msgs_to_user=[
+                    DirectoryListingResponse(
+                        listing_success=True,
+                        dir_params=params,
+                    ).to_generic_msg_to_user_tlv(),
+                    OriginatingTransactionId(transaction_id).to_generic_msg_to_user_tlv(),
+                ],
+            )
+            self.put_req_queue.put(put_req)
+        elif reserved_cfdp_msg.get_directory_operation_type() == DirectoryOperationMessageType.LISTING_RESPONSE:  # noqa: E501
+            dir_list_response_params = reserved_cfdp_msg.get_dir_listing_response_params()
+            logger.info(f"Received Directory Listing Response: {dir_list_response_params}")
 
     def file_segment_recv_indication(self, params: FileSegmentRecvdParams) -> None:
         logger.info(f"{self.base_str}: File-Segment-Recv.indication for {params.transaction_id}.")

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -13,6 +13,7 @@ from cfdppy import CfdpState
 from cfdppy.exceptions import (
     InvalidDestinationId,
     NoRemoteEntityConfigFound,
+    PduIgnoredForDest,
     PduIgnoredForSource,
     SourceFileDoesNotExist,
 )
@@ -590,7 +591,7 @@ class SourceEntityHandler(Thread):
                 assert next_pdu_wrapper is not None
                 logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
                 # Send all packets which need to be sent.
-                self.tm_queue.put(next_pdu_wrapper.pack())
+                self.tm_queue.put(next_pdu_wrapper)
                 packet_sent = True
         return packet_sent
 
@@ -655,14 +656,17 @@ class DestEntityHandler(Thread):
                 pass
             if packet is not None:
                 logger.debug(f"Dest received {packet}")
-            fsm_result = self.dest_handler.state_machine(packet)
+            try:
+                fsm_result = self.dest_handler.state_machine(packet)
+            except PduIgnoredForDest as e:
+                logger.warning(f"Ignoring PDU: {e.reason}")
             packet_sent = False
             if fsm_result.states.num_packets_ready > 0:
                 while fsm_result.states.num_packets_ready > 0:
                     next_pdu_wrapper = self.dest_handler.get_next_packet()
                     assert next_pdu_wrapper is not None
                     logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
-                    self.tm_queue.put(next_pdu_wrapper.pack())
+                    self.tm_queue.put(next_pdu_wrapper)
                     packet_sent = True
             # If there is no work to do, put the thread to sleep.
             if not packet_received and not packet_sent:

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -4,6 +4,7 @@ Most or all of these changes should eventually be submitted upstream.
 """
 
 import time
+from pathlib import Path
 from queue import Empty, SimpleQueue
 from threading import Event, Thread
 
@@ -316,8 +317,6 @@ class CfdpUser(CfdpUserBase):
 class SourceEntityHandler(Thread):
     def __init__(
         self,
-        base_str: str,
-        verbose_level: int,
         source_handler: SourceHandler,
         put_req_queue: SimpleQueue,
         source_entity_queue: SimpleQueue,
@@ -325,8 +324,6 @@ class SourceEntityHandler(Thread):
         stop_signal: Event,
     ):
         super().__init__()
-        self.base_str = base_str
-        self.verbose_level = verbose_level
         self.source_handler = source_handler
         self.put_req_queue = put_req_queue
         self.source_entity_queue = source_entity_queue
@@ -336,7 +333,7 @@ class SourceEntityHandler(Thread):
     def _idle_handling(self) -> bool:
         try:
             put_req: PutRequest = self.put_req_queue.get(False)
-            logger.info(f"{self.base_str}: Handling Put Request: {put_req}")
+            logger.info(f"Handling Put Request: {put_req}")
             if put_req.destination_id not in [LOCAL_ENTITY_ID, REMOTE_ENTITY_ID]:
                 logger.warning(
                     f"can only handle put requests target towards {REMOTE_ENTITY_ID} or "
@@ -380,7 +377,7 @@ class SourceEntityHandler(Thread):
         """Returns whether a packet was sent."""
 
         if packet is not None:
-            logger.debug(f"{self.base_str}: Inserting {packet}")
+            logger.debug(f"=Inserting {packet}")
         try:
             fsm_result = self.source_handler.state_machine(packet)
         except InvalidDestinationId as e:
@@ -395,14 +392,14 @@ class SourceEntityHandler(Thread):
                 next_pdu_wrapper = self.source_handler.get_next_packet()
                 assert next_pdu_wrapper is not None
                 if self.verbose_level >= 1:
-                    logger.debug(f"{self.base_str}: Sending packet {next_pdu_wrapper.pdu}")
+                    logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
                 # Send all packets which need to be sent.
                 self.tm_queue.put(next_pdu_wrapper.pack())
                 packet_sent = True
         return packet_sent
 
     def run(self) -> None:
-        logger.info(f"Starting {self.base_str}")
+        logger.info("Starting Source Entity Handler")
         while True:
             if self.stop_signal.is_set():
                 break
@@ -416,23 +413,19 @@ class SourceEntityHandler(Thread):
 class DestEntityHandler(Thread):
     def __init__(
         self,
-        base_str: str,
-        verbose_level: int,
         dest_handler: DestHandler,
         dest_entity_queue: SimpleQueue,
         tm_queue: SimpleQueue,
         stop_signal: Event,
     ):
         super().__init__()
-        self.base_str = base_str
-        self.verbose_level = verbose_level
         self.dest_handler = dest_handler
         self.dest_entity_queue = dest_entity_queue
         self.tm_queue = tm_queue
         self.stop_signal = stop_signal
 
     def run(self) -> None:
-        logger.info(f"Starting {self.base_str}. Local ID {self.dest_handler.cfg.local_entity_id}")
+        logger.info(f"Starting Dest Entity Handler. Local ID {self.dest_handler.cfg.local_entity_id}")
         while True:
             packet_received = False
             packet = None
@@ -444,7 +437,7 @@ class DestEntityHandler(Thread):
             except Empty:
                 pass
             if packet is not None:
-                logger.debug(f"{self.base_str}: Inserting {packet}")
+                logger.debug(f"Inserting {packet}")
             fsm_result = self.dest_handler.state_machine(packet)
             packet_sent = False
             if fsm_result.states.num_packets_ready > 0:
@@ -452,7 +445,7 @@ class DestEntityHandler(Thread):
                     next_pdu_wrapper = self.dest_handler.get_next_packet()
                     assert next_pdu_wrapper is not None
                     if self.verbose_level >= 1:
-                        logger.debug(f"{self.base_str}: Sending packet {next_pdu_wrapper.pdu}")
+                        logger.debug(f"Sending packet {next_pdu_wrapper.pdu}")
                     self.tm_queue.put(next_pdu_wrapper.pack())
                     packet_sent = True
             # If there is no work to do, put the thread to sleep.

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -68,6 +68,8 @@ from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
 
+from .cachestore import CacheStore
+
 
 class VfsSourceHandler(SourceHandler):
     """A SourceHandler but modified to always and only use Filestore operations"""
@@ -281,13 +283,13 @@ class CfdpFaultHandler(DefaultFaultHandlerBase):
 
 
 class CfdpUser(CfdpUserBase):
-    def __init__(self, base_str: str, put_req_queue: SimpleQueue):
+    def __init__(self, file_cache: CacheStore, base_str: str, put_req_queue: SimpleQueue):
         self.base_str = base_str
         self.put_req_queue = put_req_queue
         # This is a dictionary where the key is the current transaction ID for a transaction which
         # was triggered by a proxy request with an originating ID.
         self.active_proxy_put_reqs: dict[TransactionId, TransactionId] = {}
-        super().__init__()
+        super().__init__(file_cache)
 
     def transaction_indication(
         self,
@@ -486,6 +488,7 @@ class SourceEntityHandler(Thread):
         put_req_queue: SimpleQueue,
         source_entity_queue: SimpleQueue,
         tm_queue: SimpleQueue,
+        file_cache: CacheStore,
         remote_entities: RemoteEntityConfigTable,
         gnd_id: ByteFieldU8,
         sat_id: ByteFieldU8,
@@ -493,7 +496,7 @@ class SourceEntityHandler(Thread):
     ):
         super().__init__()
         src_seq_count_provider = SeqCountProvider(16)
-        src_user = CfdpUser(self.BASE_STR_SRC + sat_id.__str__(), put_req_queue)
+        src_user = CfdpUser(file_cache, self.BASE_STR_SRC + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
         self.source_handler = VfsSourceHandler(
             cfg=LocalEntityConfig(
@@ -602,13 +605,14 @@ class DestEntityHandler(Thread):
         put_req_queue: SimpleQueue,
         dest_entity_queue: SimpleQueue,
         tm_queue: SimpleQueue,
+        file_cache: CacheStore,
         remote_entities: RemoteEntityConfigTable,
         sat_id: ByteFieldU8,
         stop_signal: Event,
     ):
         super().__init__()
 
-        dest_user = CfdpUser(self.BASE_STR_DEST + sat_id.__str__(), put_req_queue)
+        dest_user = CfdpUser(file_cache, self.BASE_STR_DEST + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
         self.dest_handler = FixedDestHandler(
             cfg=LocalEntityConfig(

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -68,7 +68,7 @@ from spacepackets.cfdp.tlv import (
     TlvType,
 )
 from spacepackets.countdown import Countdown
-from spacepackets.seqcount import FileSeqCountProvider
+from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
 
 from .cachestore import CacheStore
@@ -553,10 +553,9 @@ class SourceEntityHandler(Thread):
         gnd_id: ByteFieldU8,
         sat_id: ByteFieldU8,
         stop_signal: Event,
-        seq_num_provider: FileSeqCountProvider,
     ):
         super().__init__()
-        src_seq_count_provider = seq_num_provider
+        src_seq_count_provider = SeqCountProvider(16)
         src_user = CfdpUser(file_cache, self.BASE_STR_SRC + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
         self.source_handler = VfsSourceHandler(
@@ -659,6 +658,12 @@ class SourceEntityHandler(Thread):
                 continue
             if self.source_handler.state == CfdpState.BUSY and not self._busy_handling():
                 time.sleep(0.1)
+
+    def set_seq_num(self, new: int) -> None:
+        self.source_handler.seq_num_provider.count = new
+
+    def get_seq_num(self) -> int:
+        return self.source_handler.seq_num_provider.count
 
 
 class DestEntityHandler(Thread):

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -344,7 +344,7 @@ class CfdpUser(CfdpUserBase):
                 destination_id=originating_id.source_id,
                 source_file=None,
                 dest_file=None,
-                trans_mode=True,
+                trans_mode=None,
                 closure_requested=None,
                 msgs_to_user=[
                     proxy_put_response,
@@ -440,7 +440,7 @@ class CfdpUser(CfdpUserBase):
     def report_indication(
         self,
         transaction_id: TransactionId,
-        status_report: Any,  # noqa ANN401
+        status_report,
     ) -> None:
         # TODO: p.28 of the CFDP standard specifies what information the status report parameter
         #       could contain. I think it would be better to not hardcode the type of the status

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -108,8 +108,9 @@ class VfsSourceHandler(SourceHandler):
         """Fixes the parent not sending EOFs for metadata only transactions. CCSDS 720.1-G-4 and
         YAMCS both have proxy put requests sending EOFs, so this brings cfdppy into compliance.
         """
-        if self.transmission_mode == TransmissionMode.ACKNOWLEDGED and super()._SourceHandler__handle_retransmission(
-            packet_holder
+        if (
+            self.transmission_mode == TransmissionMode.ACKNOWLEDGED
+            and super()._SourceHandler__handle_retransmission(packet_holder)
         ):
             return True
         # No need to send a file data PDU for an empty file
@@ -129,6 +130,23 @@ class VfsSourceHandler(SourceHandler):
         if self._params.fp.metadata_only:
             return b'\0' * 4
         return super()._checksum_calculation(size_to_calculate)
+
+    def _transaction_start(self) -> None:
+        # seems to be an issue where proxy put responses are expected by the source handler to have
+        # a file size. This alters the assert to allow for metadata only PDUs from the source.
+        originating_transaction_id = self._check_for_originating_id()
+        self._prepare_file_params()
+        assert self._params.fp.file_size is not None or self._params.fp.metadata_only
+        self._prepare_pdu_conf(self._params.fp.file_size)
+        self._get_next_transfer_seq_num()
+        self._calculate_max_file_seg_len()
+        self._params.transaction_id = TransactionId(
+            source_entity_id=self.cfg.local_entity_id,
+            transaction_seq_num=self.transaction_seq_num,
+        )
+        self.user.transaction_indication(
+            TransactionParams(self._params.transaction_id, originating_transaction_id)
+        )
 
 
 class FixedDestHandler(DestHandler):
@@ -202,7 +220,6 @@ class FixedDestHandler(DestHandler):
             )
             raise NoRemoteEntityConfigFound(metadata_pdu.dest_entity_id)
         self.states.step = DestTransactionStep.RECEIVING_FILE_DATA
-        logger.warning("do we get here?")
         if not self._params.fp.metadata_only:
             assert metadata_pdu.source_file_name is not None
             self._init_vfs_handling(Path(metadata_pdu.source_file_name).name)

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -201,10 +201,15 @@ class FixedDestHandler(DestHandler):
         return super()._handle_eof_without_previous_metadata(eof_pdu)
 
     def _handle_waiting_for_finished_ack(self, packet_holder: PduHolder) -> None:
-        # For some reason the upstream package will not re-send the EOF_ACK if it gets dropped.
+        """
+        The dest handler will not resend the EOF ack if it gets lost. The ordreing of the FSM means
+        that this can also try to resend when getting the normal EOF, so this does not resend if the
+        queue already has something. There is probably a cleaner way to handle this.
+        """
         if (
             packet_holder.pdu is not None
             and packet_holder.pdu_directive_type == DirectiveType.EOF_PDU
+            and self.states._num_packets_ready == 0
         ):
             self._handle_eof_pdu(packet_holder.pdu)
         super()._handle_waiting_for_finished_ack(packet_holder)
@@ -339,7 +344,7 @@ class CfdpUser(CfdpUserBase):
                 destination_id=originating_id.source_id,
                 source_file=None,
                 dest_file=None,
-                trans_mode=None,
+                trans_mode=True,
                 closure_requested=None,
                 msgs_to_user=[
                     proxy_put_response,
@@ -477,7 +482,6 @@ class CfdpUser(CfdpUserBase):
         logger.info(f"{self.base_str}: EOF-Recv.indication for {transaction_id}")
 
 
-# Don't know what this is for yet. TODO: figure that out.
 class CustomCheckTimerProvider(CheckTimerProvider):
     def provide_check_timer(
         self,

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -246,7 +246,7 @@ class FixedDestHandler(DestHandler):
         if not self._params.fp.metadata_only:
             assert metadata_pdu.source_file_name is not None
             self._init_vfs_handling(Path(metadata_pdu.source_file_name).name)
-        msgs_to_user_list: None | list[MessageToUserTlv] = None
+        msgs_to_user_list: list[MessageToUserTlv] | None = None
         options = metadata_pdu.options_as_tlv()
         if options is not None:
             msgs_to_user_list = []

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -68,7 +68,7 @@ from spacepackets.cfdp.tlv import (
     TlvType,
 )
 from spacepackets.countdown import Countdown
-from spacepackets.seqcount import SeqCountProvider
+from spacepackets.seqcount import FileSeqCountProvider
 from spacepackets.util import ByteFieldU8
 
 from .cachestore import CacheStore
@@ -195,13 +195,17 @@ class FixedDestHandler(DestHandler):
         It would be very difficult to override EofPdu directly because it gets used everywhere and
         we don't have control over where. This is the next best thing, _handle_eof_pdu is where
         the pdu gets used, so we can fix up the value before it spreads.
+
+        I've made this shelf stable for when it eventually gets fixed.
         """
-        eof_pdu.condition_code >>= 4
+        if eof_pdu.condition_code > 15:
+            eof_pdu.condition_code >>= 4
         return super()._handle_eof_pdu(eof_pdu)
 
     def _handle_eof_without_previous_metadata(self, eof_pdu: EofPdu):
         """Same issue as _handle_eof_pdu"""
-        eof_pdu.condition_code >>= 4
+        if eof_pdu.condition_code > 15:
+            eof_pdu.condition_code >>= 4
         return super()._handle_eof_without_previous_metadata(eof_pdu)
 
     def _handle_waiting_for_finished_ack(self, packet_holder: PduHolder) -> None:
@@ -326,6 +330,8 @@ class CfdpFaultHandler(DefaultFaultHandlerBase):
 
 
 class CfdpUser(CfdpUserBase):
+    DIRECTORY_LISTING_FILE = Path("c3_dirlist_0")
+
     def __init__(self, file_cache: CacheStore, base_str: str, put_req_queue: SimpleQueue):
         self.base_str = base_str
         self.put_req_queue = put_req_queue
@@ -443,10 +449,11 @@ class CfdpUser(CfdpUserBase):
             self, transaction_id: TransactionId, reserved_cfdp_msg: ReservedCfdpMessage
         ) -> None:
         params = reserved_cfdp_msg.get_dir_listing_request_params()
-        if reserved_cfdp_msg.get_directory_operation_type() == DirectoryOperationMessageType.LISTING_REQUEST:  # noqa: E501
+        if (reserved_cfdp_msg.get_directory_operation_type()
+            == DirectoryOperationMessageType.LISTING_REQUEST):
             resp = self.vfs.list_directory(
                 params.dir_path_as_path,
-                params.dir_file_name_as_path,
+                self.DIRECTORY_LISTING_FILE,
                 False
             )
             # FIXME: This fixes an issue with DirectoryListingResponse spacepackets <= 0.31.0.
@@ -460,7 +467,7 @@ class CfdpUser(CfdpUserBase):
 
             put_req = PutRequest(
                 destination_id=transaction_id.source_id,
-                source_file=params.dir_file_name_as_path,
+                source_file=self.DIRECTORY_LISTING_FILE,
                 dest_file=params.dir_file_name_as_path,
                 trans_mode=None,
                 closure_requested=True,
@@ -470,7 +477,8 @@ class CfdpUser(CfdpUserBase):
                 ],
             )
             self.put_req_queue.put(put_req)
-        elif reserved_cfdp_msg.get_directory_operation_type() == DirectoryOperationMessageType.LISTING_RESPONSE:  # noqa: E501
+        elif (reserved_cfdp_msg.get_directory_operation_type()
+            == DirectoryOperationMessageType.LISTING_RESPONSE):
             dir_list_response_params = reserved_cfdp_msg.get_dir_listing_response_params()
             logger.info(f"Received Directory Listing Response: {dir_list_response_params}")
 
@@ -545,9 +553,10 @@ class SourceEntityHandler(Thread):
         gnd_id: ByteFieldU8,
         sat_id: ByteFieldU8,
         stop_signal: Event,
+        seq_num_provider: FileSeqCountProvider,
     ):
         super().__init__()
-        src_seq_count_provider = SeqCountProvider(16)
+        src_seq_count_provider = seq_num_provider
         src_user = CfdpUser(file_cache, self.BASE_STR_SRC + sat_id.__str__(), put_req_queue)
         check_timer_provider = CustomCheckTimerProvider()
         self.source_handler = VfsSourceHandler(

--- a/oresat_c3/protocols/cfdp.py
+++ b/oresat_c3/protocols/cfdp.py
@@ -3,12 +3,57 @@
 Most or all of these changes should eventually be submitted upstream.
 """
 
-from cfdppy.exceptions import SourceFileDoesNotExist
+import time
+from queue import Empty, SimpleQueue
+from threading import Event, Thread
+
+from cfdppy import CfdpState, PacketDestination, get_packet_destination
+from cfdppy.exceptions import (
+    InvalidDestinationId,
+    NoRemoteEntityConfigFound,
+    SourceFileDoesNotExist,
+)
 from cfdppy.handler.dest import CompletionDisposition, DestHandler
 from cfdppy.handler.source import SourceHandler
-from spacepackets.cfdp import ConditionCode
-from spacepackets.cfdp.pdu import EofPdu, FileDataPdu
+from cfdppy.mib import (
+    CheckTimerProvider,
+    DefaultFaultHandlerBase,
+    EntityType,
+    IndicationConfig,
+    LocalEntityConfig,
+    RemoteEntityConfig,
+    RemoteEntityConfigTable,
+)
+from cfdppy.request import PutRequest
+from cfdppy.user import (
+    CfdpUserBase,
+    FileSegmentRecvdParams,
+    MetadataRecvParams,
+    TransactionFinishedParams,
+    TransactionParams,
+)
+from olaf import logger
+from spacepackets.cfdp import (
+    ChecksumType,
+    ConditionCode,
+    FaultHandlerCode,
+    PduHolder,
+    TransmissionMode,
+)
+from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
+from spacepackets.cfdp.pdu import AbstractFileDirectiveBase, EofPdu, FileDataPdu
 from spacepackets.cfdp.pdu.file_data import FileDataParams
+from spacepackets.cfdp.tlv import (
+    DirectoryListingResponse,
+    DirectoryOperationMessageType,
+    MessageToUserTlv,
+    OriginatingTransactionId,
+    ProxyMessageType,
+    ProxyPutResponse,
+    ProxyPutResponseParams,
+    ReservedCfdpMessage,
+)
+from spacepackets.util import ByteFieldU8
 
 
 class VfsSourceHandler(SourceHandler):
@@ -96,3 +141,321 @@ class FixedDestHandler(DestHandler):
         """Same issue as _handle_eof_pdu"""
         eof_pdu.condition_code >>= 4
         return super()._handle_eof_without_previous_metadata(eof_pdu)
+
+
+class CfdpUser(CfdpUserBase):
+    def __init__(self, base_str: str, put_req_queue: SimpleQueue):
+        self.base_str = base_str
+        self.put_req_queue = put_req_queue
+        # This is a dictionary where the key is the current transaction ID for a transaction which
+        # was triggered by a proxy request with an originating ID.
+        self.active_proxy_put_reqs: dict[TransactionId, TransactionId] = {}
+        super().__init__()
+
+    def transaction_indication(
+        self,
+        transaction_indication_params: TransactionParams,
+    ) -> None:
+        """This indication is used to report the transaction ID to the CFDP user"""
+        logger.info(
+            f"{self.base_str}: Transaction.indication for"
+            f" {transaction_indication_params.transaction_id}"
+        )
+        if transaction_indication_params.originating_transaction_id is not None:
+            logger.info(
+                f"Originating Transaction ID:"
+                f" {transaction_indication_params.originating_transaction_id}"
+            )
+            self.active_proxy_put_reqs.update(
+                {
+                    transaction_indication_params.transaction_id: transaction_indication_params.originating_transaction_id  # noqa: E501
+                }
+            )
+
+    def eof_sent_indication(self, transaction_id: TransactionId) -> None:
+        logger.info(f"{self.base_str}: EOF-Sent.indication for {transaction_id}")
+
+    def transaction_finished_indication(self, params: TransactionFinishedParams) -> None:
+        logger.info(
+            f"{self.base_str}: Transaction-Finished.indication for {params.transaction_id}."
+        )
+        logger.info(f"Condition Code: {params.finished_params.condition_code!r}")
+        logger.info(f"Delivery Code: {params.finished_params.delivery_code!r}")
+        logger.info(f"File Status: {params.finished_params.file_status!r}")
+        if params.transaction_id in self.active_proxy_put_reqs:
+            proxy_put_response = ProxyPutResponse(
+                ProxyPutResponseParams.from_finished_params(params.finished_params)
+            ).to_generic_msg_to_user_tlv()
+            originating_id = self.active_proxy_put_reqs.get(params.transaction_id)
+            assert originating_id is not None
+            put_req = PutRequest(
+                destination_id=originating_id.source_id,
+                source_file=None,
+                dest_file=None,
+                trans_mode=None,
+                closure_requested=None,
+                msgs_to_user=[
+                    proxy_put_response,
+                    OriginatingTransactionId(originating_id).to_generic_msg_to_user_tlv(),
+                ],
+            )
+            logger.info(
+                f"Requesting Proxy Put Response concluding Proxy Put originating from "
+                f"{originating_id}"
+            )
+            self.put_req_queue.put(put_req)
+            self.active_proxy_put_reqs.pop(params.transaction_id)
+
+    def metadata_recv_indication(self, params: MetadataRecvParams) -> None:
+        logger.info(f"{self.base_str}: Metadata-Recv.indication for {params.transaction_id}.")
+        if params.msgs_to_user is not None:
+            self._handle_msgs_to_user(params.transaction_id, params.msgs_to_user)
+
+    def _handle_msgs_to_user(
+        self, transaction_id: TransactionId, msgs_to_user: list[MessageToUserTlv]
+    ) -> None:
+        for msg_to_user in msgs_to_user:
+            if msg_to_user.is_reserved_cfdp_message():
+                reserved_msg_tlv = msg_to_user.to_reserved_msg_tlv()
+                assert reserved_msg_tlv is not None
+                self._handle_reserved_cfdp_message(transaction_id, reserved_msg_tlv)
+            else:
+                logger.info(f"Received custom message to user: {msg_to_user}")
+
+    def _handle_reserved_cfdp_message(
+        self, transaction_id: TransactionId, reserved_cfdp_msg: ReservedCfdpMessage
+    ) -> None:
+        if reserved_cfdp_msg.is_cfdp_proxy_operation():
+            self._handle_cfdp_proxy_operation(transaction_id, reserved_cfdp_msg)
+        elif reserved_cfdp_msg.is_originating_transaction_id():
+            logger.info(
+                f"Received originating transaction ID: "
+                f"{reserved_cfdp_msg.get_originating_transaction_id()}"
+            )
+
+    def _handle_cfdp_proxy_operation(
+        self, transaction_id: TransactionId, reserved_cfdp_msg: ReservedCfdpMessage
+    ) -> None:
+        if reserved_cfdp_msg.get_cfdp_proxy_message_type() == ProxyMessageType.PUT_REQUEST:
+            put_req_params = reserved_cfdp_msg.get_proxy_put_request_params()
+            logger.info(f"Received Proxy Put Request: {put_req_params}")
+            assert put_req_params is not None
+            put_req = PutRequest(
+                destination_id=put_req_params.dest_entity_id,
+                source_file=Path(put_req_params.source_file_as_path),
+                dest_file=Path(put_req_params.dest_file_as_path), # Don't really understand why this needs a path. TODO: understand and fix.
+                trans_mode=None,
+                closure_requested=None,
+                msgs_to_user=[
+                    OriginatingTransactionId(transaction_id).to_generic_msg_to_user_tlv()
+                ],
+            )
+            self.put_req_queue.put(put_req)
+        elif reserved_cfdp_msg.get_cfdp_proxy_message_type() == ProxyMessageType.PUT_RESPONSE:
+            put_response_params = reserved_cfdp_msg.get_proxy_put_response_params()
+            logger.info(f"Received Proxy Put Response: {put_response_params}")
+
+    def file_segment_recv_indication(self, params: FileSegmentRecvdParams) -> None:
+        logger.info(f"{self.base_str}: File-Segment-Recv.indication for {params.transaction_id}.")
+
+    def report_indication(
+        self,
+        transaction_id: TransactionId,
+        status_report: Any,  # noqa ANN401
+    ) -> None:
+        # TODO: p.28 of the CFDP standard specifies what information the status report parameter
+        #       could contain. I think it would be better to not hardcode the type of the status
+        #       report here, but something like Union[any, CfdpStatusReport] with CfdpStatusReport
+        #       being an implementation which supports all three information suggestions would be
+        #       nice
+        pass
+
+    def suspended_indication(self, transaction_id: TransactionId, cond_code: ConditionCode) -> None:
+        logger.info(
+            f"{self.base_str}: Suspended.indication for {transaction_id} |"
+            f" Condition Code: {cond_code}"
+        )
+
+    def resumed_indication(self, transaction_id: TransactionId, progress: int) -> None:
+        logger.info(
+            f"{self.base_str}: Resumed.indication for {transaction_id} | Progress: {progress} bytes"
+        )
+
+    def fault_indication(
+        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
+    ) -> None:
+        logger.info(
+            f"{self.base_str}: Fault.indication for {transaction_id} |"
+            f" Condition Code: {cond_code} | "
+            f"Progress: {progress} bytes"
+        )
+
+    def abandoned_indication(
+        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
+    ) -> None:
+        logger.info(
+            f"{self.base_str}: Abandoned.indication for {transaction_id} |"
+            f" Condition Code: {cond_code} |"
+            f" Progress: {progress} bytes"
+        )
+
+    def eof_recv_indication(self, transaction_id: TransactionId) -> None:
+        logger.info(f"{self.base_str}: EOF-Recv.indication for {transaction_id}")
+
+# Don't know what this is for yet. TODO: figure that out.
+# class CustomCheckTimerProvider(CheckTimerProvider):
+#     def provide_check_timer(
+#         self,
+#         local_entity_id: ByteFieldU8,
+#         remote_entity_id: ByteFieldU8,
+#         entity_type: EntityType,
+#     ) -> Countdown:
+#         return Countdown(timedelta(seconds=5.0))
+
+
+class SourceEntityHandler(Thread):
+    def __init__(
+        self,
+        base_str: str,
+        verbose_level: int,
+        source_handler: SourceHandler,
+        put_req_queue: SimpleQueue,
+        source_entity_queue: SimpleQueue,
+        tm_queue: SimpleQueue,
+        stop_signal: Event,
+    ):
+        super().__init__()
+        self.base_str = base_str
+        self.verbose_level = verbose_level
+        self.source_handler = source_handler
+        self.put_req_queue = put_req_queue
+        self.source_entity_queue = source_entity_queue
+        self.tm_queue = tm_queue
+        self.stop_signal = stop_signal
+
+    def _idle_handling(self) -> bool:
+        try:
+            put_req: PutRequest = self.put_req_queue.get(False)
+            logger.info(f"{self.base_str}: Handling Put Request: {put_req}")
+            if put_req.destination_id not in [LOCAL_ENTITY_ID, REMOTE_ENTITY_ID]:
+                logger.warning(
+                    f"can only handle put requests target towards {REMOTE_ENTITY_ID} or "
+                    f"{LOCAL_ENTITY_ID}" # These were global variables. TODO: fix
+                )
+
+            else:
+                try:
+                    self.source_handler.put_request(put_req)
+                    return True
+                except SourceFileDoesNotExist as e:
+                    logger.warning(
+                        f"can not handle put request, source file {e.file} does not exist"
+                    )
+        except Empty:
+            pass
+        return False
+
+    def _busy_handling(self) -> bool | None:
+        # We are getting the packets from a Queue here, they could for example also be polled
+        # from a network.
+        packet_received = False
+        packet = None
+        try:
+            # We are getting the packets from a Queue here, they could for example also be polled
+            # from a network.
+            packet = self.source_entity_queue.get(False)
+            packet_received = True
+        except Empty:
+            pass
+        try:
+            packet_sent = self._call_source_state_machine(packet)
+            # If there is no work to do, put the thread to sleep.
+            if not packet_received and not packet_sent:
+                return False
+        except SourceFileDoesNotExist:
+            logger.warning("Source file does not exist")
+            self.source_handler.reset()
+
+    def _call_source_state_machine(self, packet: AbstractFileDirectiveBase | None) -> bool:
+        """Returns whether a packet was sent."""
+
+        if packet is not None:
+            logger.debug(f"{self.base_str}: Inserting {packet}")
+        try:
+            fsm_result = self.source_handler.state_machine(packet)
+        except InvalidDestinationId as e:
+            logger.warning(
+                f"invalid destination ID {e.found_dest_id} on packet {packet}, expected "
+                f"{e.expected_dest_id}"
+            )
+            fsm_result = self.source_handler.state_machine(None)
+        packet_sent = False
+        if fsm_result.states.num_packets_ready > 0:
+            while fsm_result.states.num_packets_ready > 0:
+                next_pdu_wrapper = self.source_handler.get_next_packet()
+                assert next_pdu_wrapper is not None
+                if self.verbose_level >= 1:
+                    logger.debug(f"{self.base_str}: Sending packet {next_pdu_wrapper.pdu}")
+                # Send all packets which need to be sent.
+                self.tm_queue.put(next_pdu_wrapper.pack())
+                packet_sent = True
+        return packet_sent
+
+    def run(self) -> None:
+        logger.info(f"Starting {self.base_str}")
+        while True:
+            if self.stop_signal.is_set():
+                break
+            if self.source_handler.state == CfdpState.IDLE and not self._idle_handling():
+                time.sleep(0.2)
+                continue
+            if self.source_handler.state == CfdpState.BUSY and not self._busy_handling():
+                time.sleep(0.2)
+
+
+class DestEntityHandler(Thread):
+    def __init__(
+        self,
+        base_str: str,
+        verbose_level: int,
+        dest_handler: DestHandler,
+        dest_entity_queue: SimpleQueue,
+        tm_queue: SimpleQueue,
+        stop_signal: Event,
+    ):
+        super().__init__()
+        self.base_str = base_str
+        self.verbose_level = verbose_level
+        self.dest_handler = dest_handler
+        self.dest_entity_queue = dest_entity_queue
+        self.tm_queue = tm_queue
+        self.stop_signal = stop_signal
+
+    def run(self) -> None:
+        logger.info(f"Starting {self.base_str}. Local ID {self.dest_handler.cfg.local_entity_id}")
+        while True:
+            packet_received = False
+            packet = None
+            if self.stop_signal.is_set():
+                break
+            try:
+                packet = self.dest_entity_queue.get(False)
+                packet_received = True
+            except Empty:
+                pass
+            if packet is not None:
+                logger.debug(f"{self.base_str}: Inserting {packet}")
+            fsm_result = self.dest_handler.state_machine(packet)
+            packet_sent = False
+            if fsm_result.states.num_packets_ready > 0:
+                while fsm_result.states.num_packets_ready > 0:
+                    next_pdu_wrapper = self.dest_handler.get_next_packet()
+                    assert next_pdu_wrapper is not None
+                    if self.verbose_level >= 1:
+                        logger.debug(f"{self.base_str}: Sending packet {next_pdu_wrapper.pdu}")
+                    self.tm_queue.put(next_pdu_wrapper.pack())
+                    packet_sent = True
+            # If there is no work to do, put the thread to sleep.
+            if not packet_received and not packet_sent:
+                time.sleep(0.5)
+

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -120,6 +120,8 @@ class EdlService(Service):
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
                     crc_type=ChecksumType.MODULAR,  # Yamcs only supports the legacy modular crc.
+                    immediate_nak_mode=False,
+                    nak_timer_interval_seconds=5.0,
                 ),
             ]
         )
@@ -243,10 +245,13 @@ class EdlService(Service):
 
     def _handle_pdu(self, pdu: AbstractFileDirectiveBase):
         packet_dest = get_packet_destination(pdu)
+        logger.warning(f"putting cfdp pdu in {packet_dest} queue")
         if packet_dest == PacketDestination.DEST_HANDLER:
             self._cfdp_dest_queue.put(pdu)
         elif packet_dest == PacketDestination.SOURCE_HANDLER:
             self._cfdp_src_queue.put(pdu)
+        else:
+            logger.error("receieved CFDP pdu intended for unknown destination!")
 
     def on_loop(self):
         self._process_command()

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -108,9 +108,9 @@ class EdlService(Service):
             self._event.set()
 
         if self._cfdp_source_handler.is_alive():
-            self._thread.join()
+            self._cfdp_source_handler.join()
         if self._cfdp_dest_handler.is_alive():
-            self._thread.join()
+            self._cfdp_dest_handler.join()
 
         if self._thread.is_alive():
             self._thread.join()

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -1,6 +1,5 @@
 """'EDL Service"""
 
-from pathlib import Path
 from queue import Empty, SimpleQueue
 from time import time
 from typing import Any, Optional, Union
@@ -18,7 +17,6 @@ from spacepackets.cfdp import (
     TransmissionMode,
 )
 from spacepackets.cfdp.pdu import AbstractFileDirectiveBase
-from spacepackets.seqcount import FileSeqCountProvider
 from spacepackets.uslp import TransferFrame
 from spacepackets.util import ByteFieldU8
 
@@ -81,11 +79,7 @@ class EdlService(Service):
 
         self.GND_ID = ByteFieldU8(0)
         self.SAT_ID = ByteFieldU8(1)
-        self._cfdp_src_seq_num = FileSeqCountProvider(
-            16,
-            Path(node.work_base_dir + "/cfdp_src_seq.txt")
-        )
-        self._init_cfdp(node.fwrite_cache, self._cfdp_src_seq_num)
+        self._init_cfdp(node.fwrite_cache)
 
         # objs
         edl_rec = node.od["edl"]
@@ -96,7 +90,17 @@ class EdlService(Service):
         self._last_tx_enable_obj = tx_rec["last_enable_timestamp"]
         self._edl_sequence_count_obj = edl_rec["sequence_count"]
         self._edl_rejected_count_obj = edl_rec["rejected_count"]
+        self._edl_cfdp_seq_count_obj = edl_rec["cfdp_seq_num"]
         self._last_edl_obj = edl_rec["last_timestamp"]
+
+    def on_start(self) -> None:
+        self._cfdp_source_handler.set_seq_num(self._edl_cfdp_seq_count_obj.value)
+        self.node.add_sdo_callbacks(
+            "edl",
+            "cfdp_seq_num",
+            self._cfdp_source_handler.get_seq_num,
+            self._cfdp_source_handler.set_seq_num,
+        )
 
     def __del__(self) -> None:
         # redefinition of the service destructor to handle the cfdp threads
@@ -111,7 +115,7 @@ class EdlService(Service):
         if self._thread.is_alive():
             self._thread.join()
 
-    def _init_cfdp(self, fwrite_cache: CacheStore, src_seq_num: FileSeqCountProvider) -> None:
+    def _init_cfdp(self, fwrite_cache: CacheStore) -> None:
         remote_entities = RemoteEntityConfigTable(
             [
                 RemoteEntityConfig(
@@ -140,7 +144,6 @@ class EdlService(Service):
             self.GND_ID,
             self.SAT_ID,
             self._event,
-            src_seq_num,
         )
         self._cfdp_dest_handler = DestEntityHandler(
             self.put_req_queue,

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -1,59 +1,29 @@
 """'EDL Service"""
 
-from datetime import timedelta
-from pathlib import Path
 from queue import Empty, SimpleQueue
 from time import time
 from typing import Any, Optional, Union
 
 import canopen
-from cfdppy import CfdpState, PacketDestination, get_packet_destination
-from cfdppy.exceptions import NoRemoteEntityConfigFound, SourceFileDoesNotExist
+from cfdppy import PacketDestination, get_packet_destination
 from cfdppy.mib import (
-    CheckTimerProvider,
-    DefaultFaultHandlerBase,
-    IndicationConfig,
-    LocalEntityConfig,
     RemoteEntityConfig,
     RemoteEntityConfigTable,
-)
-from cfdppy.request import PutRequest
-from cfdppy.user import (
-    CfdpUserBase,
-    FileSegmentRecvdParams,
-    MetadataRecvParams,
-    TransactionFinishedParams,
-    TransactionParams,
 )
 from olaf import MasterNode, NodeStop, Service, logger
 from spacepackets.cfdp import (
     ChecksumType,
-    ConditionCode,
-    FaultHandlerCode,
     PduHolder,
     TransmissionMode,
 )
-from spacepackets.cfdp.defs import DeliveryCode, FileStatus, TransactionId
 from spacepackets.cfdp.pdu import AbstractFileDirectiveBase
-from spacepackets.cfdp.tlv import (
-    DirectoryListingResponse,
-    DirectoryOperationMessageType,
-    OriginatingTransactionId,
-    ProxyMessageType,
-    ProxyPutResponse,
-    ProxyPutResponseParams,
-)
-from spacepackets.countdown import Countdown
-from spacepackets.seqcount import SeqCountProvider
 from spacepackets.uslp import TransferFrame
 from spacepackets.util import ByteFieldU8
 
 from ..protocols.cachestore import CacheStore
 from ..protocols.cfdp import (
     DestEntityHandler,
-    FixedDestHandler,
     SourceEntityHandler,
-    VfsSourceHandler,
 )
 from ..protocols.edl_command import (
     EdlCommandCode,
@@ -109,8 +79,8 @@ class EdlService(Service):
 
         self.GND_ID = ByteFieldU8(0)
         self.SAT_ID = ByteFieldU8(1)
+        self._init_cfdp(node.fwrite_cache)
 
-        self._file_receiver = EdlFileReciever(node.fwrite_cache)
 
         # objs
         edl_rec = node.od["edl"]
@@ -138,28 +108,28 @@ class EdlService(Service):
                     closure_requested=False,
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
-                    crc_type=ChecksumType.MODULAR,
+                    crc_type=ChecksumType.MODULAR,  # Yamcs only supports the legacy modular crc.
                 ),
             ]
         )
-
         self.cfdp_source_handler = SourceEntityHandler(
-            self.put_req_queue,
+            self._put_req_queue,
             self._cfdp_src_queue,
             self._cfdp_tm_queue,
-            fwrite_cache,
+            self.fwrite_cache,
             remote_entities,
-            self.GND_ID,
-            self.SAT_ID
+            self.gnd_id,
+            self.sat_id,
+            self.stop_signal
         )
-
         self.cfdp_dest_handler = DestEntityHandler(
-            self.put_req_queue,
+            self._put_req_queue,
             self._cfdp_dest_queue,
             self._cfdp_tm_queue,
-            fwrite_cache,
+            self.fwrite_cache,
             remote_entities,
-            self.SAT_ID
+            self.sat_id,
+            self.stop_signal
         )
 
     @property
@@ -251,16 +221,20 @@ class EdlService(Service):
         else:
             req_packet = None
 
-        if req_packet is None:
-            if self._file_receiver.state == CfdpState.BUSY:
-                res_payload = self._file_receiver.loop(None)
-            else:
-                return
-        else:
-            res_payload = self._file_receiver.loop(req_packet.payload)
+        if req_packet is not None:
+            self._handle_pdu(req_packet)
 
-        for payload in res_payload:
-            self._respond(EdlVcid.FILE_TRANSFER, payload)
+        while not self._cfdp_tm_queue.empty():
+            next_tm = self._cfdp_tm_queue.get(False)
+            self._respond(EdlVcid.FILE_TRANSFER, next_tm)
+
+    def _handle_pdu(self, pdu: AbstractFileDirectiveBase):
+        packet_dest = get_packet_destination(pdu)
+        logger.debug(f"UDP server: Routing {pdu} to {packet_dest}")
+        if packet_dest == PacketDestination.DEST_HANDLER:
+            self._cfdp_dest_queue.put(pdu)
+        elif packet_dest == PacketDestination.SOURCE_HANDLER:
+            self._cfdp_src_queue.put(pdu)
 
     def on_loop(self):
         self._process_command()
@@ -443,344 +417,3 @@ class EdlService(Service):
         logger.info(f"EDL command response: {response.code.name}, values: {response.values}")
 
         return response
-
-
-class LogFaults(DefaultFaultHandlerBase):
-    """A HaultHandler that only logs the faults and nothing more.
-
-    At some point this should be replaced with something more robust.
-    """
-
-    def notice_of_suspension_cb(self, transaction_id, cond, progress):
-        logger.info(f"Transaction {transaction_id} suspended: {cond}. Progress {progress}")
-
-    def notice_of_cancellation_cb(self, transaction_id, cond, progress):
-        logger.info(f"Transaction {transaction_id} cancelled: {cond}. Progress {progress}")
-
-    def abandoned_cb(self, transaction_id, cond, progress):
-        logger.info(f"Transaction {transaction_id} abandoned: {cond}. Progress {progress}")
-
-    def ignore_cb(self, transaction_id, cond, progress):
-        logger.info(f"Transaction {transaction_id} ignored: {cond}. Progress {progress}")
-
-
-class DefaultCheckTimer(CheckTimerProvider):
-    """A straight copy of the example CheckTimerProvider
-
-    I think this exists to possibly account for the latency between local and remote entities?
-    Unfortunately it doesn't get used for all the timers in source/dest, like the ACK timer.
-    """
-
-    def provide_check_timer(self, local_entity_id, remote_entity_id, entity_type) -> Countdown:
-        return Countdown(timedelta(seconds=5.0))
-
-
-class EdlFileReciever(CfdpUserBase):
-    """CFDP receiver for file uploads."""
-
-    def __init__(self, fwrite_cache: CacheStore):
-        super().__init__(vfs=fwrite_cache)
-
-        self.proxy_responses = {  # FIXME: defaultdict with invalid response
-            ProxyMessageType.PUT_REQUEST: self.proxy_put_response,
-            ProxyMessageType.MSG_TO_USER: self.unimplemented,
-            ProxyMessageType.FS_REQUEST: self.unimplemented,
-            ProxyMessageType.FAULT_HANDLER_OVERRIDE: self.unimplemented,
-            ProxyMessageType.TRANSMISSION_MODE: self.transmission_mode_response,
-            ProxyMessageType.FLOW_LABEL: self.unimplemented,
-            ProxyMessageType.SEGMENTATION_CTRL: self.unimplemented,
-            ProxyMessageType.PUT_RESPONSE: self.unimplemented,
-            ProxyMessageType.FS_RESPONSE: self.unimplemented,
-            ProxyMessageType.PUT_CANCEL: self.unimplemented,
-            ProxyMessageType.CLOSURE_REQUEST: self.unimplemented,
-            DirectoryOperationMessageType.LISTING_REQUEST: self.directory_listing_response,
-            DirectoryOperationMessageType.LISTING_RESPONSE: self.unimplemented,
-            DirectoryOperationMessageType.CUSTOM_LISTING_PARAMETERS: self.unimplemented,
-        }
-
-        SOURCE_ID = ByteFieldU8(0)
-        DEST_ID = ByteFieldU8(1)
-        fault_handler = LogFaults()
-        # The default setting is NOTICE_OF_CANCELLATION but during that process the positive ack
-        # counter gets reset, meaning we keep retrying the handler forever. This manifests for
-        # example if the final source -> dest ack for FinishedPDU gets dropped. Source considers
-        # the transaction finished, and will refuse to respond, dest will be stuck re-sending the
-        # FinishedPDU every ack_timer interval forever. Setting it to ABANDON_TRANSACTION means it
-        # just resets after the ack counter reaches its count.
-        fault_handler.set_handler(
-            ConditionCode.POSITIVE_ACK_LIMIT_REACHED, FaultHandlerCode.ABANDON_TRANSACTION
-        )
-
-        localcfg = LocalEntityConfig(
-            local_entity_id=DEST_ID,
-            indication_cfg=IndicationConfig(),
-            default_fault_handlers=fault_handler,
-        )
-
-        remote_entities = RemoteEntityConfigTable(
-            [
-                RemoteEntityConfig(
-                    entity_id=SOURCE_ID,
-                    max_file_segment_len=None,
-                    # FIXME this value should come from EdlPacket but EdlPacket does not define it.
-                    # How does the exact value get determined? Currently it's just a mirror of the
-                    # value in edl_file_upload.py
-                    max_packet_len=950,
-                    closure_requested=False,
-                    crc_on_transmission=False,
-                    default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
-                    crc_type=ChecksumType.MODULAR,
-                ),
-            ]
-        )
-
-        self.dest = FixedDestHandler(
-            cfg=localcfg,
-            user=self,
-            remote_cfg_table=remote_entities,
-            check_timer_provider=DefaultCheckTimer(),
-        )
-
-        self.source = VfsSourceHandler(
-            cfg=localcfg,
-            user=self,
-            remote_cfg_table=remote_entities,
-            check_timer_provider=DefaultCheckTimer(),
-            seq_num_provider=SeqCountProvider(16),
-        )
-
-        self.scheduled_requests: SimpleQueue[PutRequest] = SimpleQueue()
-        self.active_requests: dict[TransactionId, TransactionId] = {}
-
-    @property
-    def state(self) -> CfdpState:
-        """Either BUSY or IDLE
-
-        The FileReceiver is BUSY if either source or dest are busy, or if there's a request yet
-        to be initiated.
-        """
-
-        if (
-            self.dest.state == CfdpState.BUSY
-            or self.source.state == CfdpState.BUSY
-            or not self.scheduled_requests.empty()
-        ):
-            return CfdpState.BUSY
-        return CfdpState.IDLE
-
-    def loop(self, pdu: AbstractFileDirectiveBase):
-        """The state machine driver for a CFDP dest, expected to be run by the service loop"""
-
-        # DestHandler is driven by either a new pdu to process or timers expiring and
-        # SourceHandler is additionally driven by Put requests.
-        # Timers only expire when .state_machine() is called, and .state_machine() must
-        # be called after all the packets have been drained, or after inserting a new
-        # pdu.
-        tick_dest = True
-        tick_src = True
-        if pdu:
-            logger.info(f"<--- {pdu}")
-
-            if get_packet_destination(pdu) == PacketDestination.DEST_HANDLER:
-                try:
-                    self.dest.state_machine(pdu)
-                    tick_dest = False
-                except Exception as e:
-                    logger.exception(f"CFDP raised: {e}")
-                    self.dest.reset()
-            else:
-                try:
-                    self.source.state_machine(pdu)
-                    tick_src = False
-                except Exception as e:
-                    logger.exception(f"CFDP raised: {e}")
-                    self.source.reset()
-
-        if self.dest.state == CfdpState.IDLE and self.source.state == CfdpState.IDLE:
-            try:
-                request = self.scheduled_requests.get_nowait()
-            except Empty:
-                pass
-            else:
-                try:
-                    self.source.put_request(request)
-                except (SourceFileDoesNotExist, NoRemoteEntityConfigFound):
-                    # Note that NoRemoteEntityConfigFound indicates that the MIB is missing info on
-                    # the requested proxy transfer destination. CFDP doesn't seem to have a
-                    # standard set of errors that cover this condition, and the least worst option
-                    # resulted in an identical message to missing_file. Not super great, so if
-                    # there's a better idea of how to handle this, please change.
-                    self.scheduled_requests.put(self.missing_file_response(request))
-
-        try:
-            if tick_dest:
-                self.dest.state_machine()
-            if tick_src:
-                self.source.state_machine()
-        except Exception as e:
-            logger.exception(f"Failed to update state machine: {e}")
-            self.dest.reset()
-            self.source.reset()
-        # It would seem natural to use dest.packets_ready but the count seems to get desynced from
-        # the contents of the packet queue. get_next_packet operates on the queue directly and
-        # reutrns None when it's out of packets. FIXME: Upstream bug?
-        pdus = []
-        while (packet := self.dest.get_next_packet()) is not None:
-            pdus.append(packet.pdu)
-        while (packet := self.source.get_next_packet()) is not None:
-            pdus.append(packet.pdu)
-
-        for out in pdus:
-            logger.info(f"---> {out}")
-        return pdus
-
-    def unimplemented(self, _source, _tid, _reserved_message) -> PutRequest:
-        """Default method for responding to unimplemented requests"""
-        logger.error(f"Recieved unimplemented request: {_reserved_message}")
-        return None
-
-    def missing_file_response(self, invalid: PutRequest) -> PutRequest:
-        """Generates a resonse put for when a proxy request tries to access a missing file"""
-
-        originating_id = (
-            invalid.msgs_to_user[0].to_reserved_msg_tlv().get_originating_transaction_id()
-        )
-        return PutRequest(
-            destination_id=originating_id.source_id,
-            source_file=None,
-            dest_file=None,
-            trans_mode=None,
-            # FIXME: upstream bug - DestHandler does not respect closure_requested=None when
-            # trans_mode defaults to ACKNOWLEGED
-            closure_requested=True,
-            msgs_to_user=[
-                ProxyPutResponse(
-                    ProxyPutResponseParams(
-                        condition_code=ConditionCode.FILESTORE_REJECTION,
-                        delivery_code=DeliveryCode.DATA_COMPLETE,
-                        file_status=FileStatus.DISCARDED_FILESTORE_REJECTION,
-                    )
-                ).to_generic_msg_to_user_tlv(),
-                OriginatingTransactionId(originating_id).to_generic_msg_to_user_tlv(),
-            ],
-        )
-
-    def proxy_put_response(self, _source, _tid, reserved_message) -> PutRequest:
-        """Response for a proxy put request"""
-        params = reserved_message.get_proxy_put_request_params()
-        return PutRequest(
-            destination_id=params.dest_entity_id,
-            source_file=Path(params.source_file_as_path),
-            dest_file=Path(params.dest_file_as_path),
-            trans_mode=None,
-            closure_requested=True,
-            msgs_to_user=[OriginatingTransactionId(_tid).to_generic_msg_to_user_tlv()],
-        )
-
-    def directory_listing_response(self, source, tid, reserved_message) -> PutRequest:
-        """Response for a directory listing request"""
-        # See CFDP 6.3.4
-        params = reserved_message.get_dir_listing_request_params()
-        self.vfs.list_directory(params.dir_path_as_path, params.dir_file_name_as_path, False)
-        return PutRequest(
-            destination_id=source,
-            source_file=params.dir_file_name_as_path,
-            dest_file=params.dir_file_name_as_path,
-            trans_mode=None,
-            closure_requested=True,
-            msgs_to_user=[
-                DirectoryListingResponse(
-                    listing_success=True,
-                    dir_params=params,
-                ).to_generic_msg_to_user_tlv(),
-                OriginatingTransactionId(tid).to_generic_msg_to_user_tlv(),
-            ],
-        )
-
-    def transmission_mode_response(self, source, tid, reserved_message) -> TransmissionMode:
-        """Attempts to set the transmission mode of the current transaction"""
-        return reserved_message.get_proxy_transmission_mode()
-
-    def proxy_request_complete(self, originating_id, params) -> PutRequest:
-        """Indicates that a proxy put request was successful"""
-        return PutRequest(
-            destination_id=originating_id.source_id,
-            source_file=None,
-            dest_file=None,
-            trans_mode=None,
-            # FIXME: upstream bug - DestHandler does not respect closure_requested=None when
-            # trans_mode defaults to ACKNOWLEGED
-            closure_requested=True,
-            msgs_to_user=[
-                ProxyPutResponse(
-                    ProxyPutResponseParams.from_finished_params(params.finished_params)
-                ).to_generic_msg_to_user_tlv(),
-                OriginatingTransactionId(originating_id).to_generic_msg_to_user_tlv(),
-            ],
-        )
-
-    def transaction_indication(self, transaction_indication_params: TransactionParams):
-        logger.info(f"Indication: Transaction. {transaction_indication_params}")
-        t_id = transaction_indication_params.transaction_id
-        orig = transaction_indication_params.originating_transaction_id
-        if orig is not None:
-            self.active_requests[t_id] = orig
-
-    def eof_sent_indication(self, transaction_id: TransactionId):
-        logger.info(f"Indication: EOF Sent for {transaction_id}.")
-
-    def transaction_finished_indication(self, params: TransactionFinishedParams):
-        logger.info(f"Indication: Transaction Finished. {params}")
-        if params.transaction_id in self.active_requests:
-            originating_id = self.active_requests.get(params.transaction_id)
-            assert originating_id is not None
-            put = self.proxy_request_complete(originating_id, params)
-            self.scheduled_requests.put(put)
-            del self.active_requests[params.transaction_id]
-
-    def metadata_recv_indication(self, params: MetadataRecvParams):
-        logger.info(f"Indication: Metadata Recv. {params}")
-        put = None
-        for msg in params.msgs_to_user or []:
-            if r := msg.to_reserved_msg_tlv():  # is None if not a reserved TLV message
-                # cfdp_proxy_message_type can be 0
-                op = r.get_cfdp_proxy_message_type()
-                if op is None:
-                    op = r.get_directory_operation_type()
-                response = self.proxy_responses[op](params.source_id, params.transaction_id, r)
-                if put is not None and response is PutRequest:
-                    self.scheduled_requests.put(put)
-                # CFDP can contain multiple requess in one indication, each refering to how the
-                # proxy put request is handled. This should be rewritten to account for that.
-                elif isinstance(response, TransmissionMode):
-                    put.trans_mode = response
-                elif isinstance(response, PutRequest):
-                    put = response
-            # Ignore non-reserved messages for now
-        if put is not None:
-            self.scheduled_requests.put(put)
-
-    def file_segment_recv_indication(self, params: FileSegmentRecvdParams):
-        logger.info(f"Indication: File Segment Recv. {params}")
-
-    def report_indication(self, transaction_id: TransactionId, status_report: Any):
-        logger.info(f"Indication: Report for {transaction_id}. {status_report}")
-
-    def suspended_indication(self, transaction_id: TransactionId, cond_code: ConditionCode):
-        logger.info(f"Indication: Suspended for {transaction_id}. {cond_code}")
-
-    def resumed_indication(self, transaction_id: TransactionId, progress: int):
-        logger.info(f"Indication: Resumed for {transaction_id}. {progress}")
-
-    def fault_indication(
-        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
-    ):
-        logger.info(f"Indication: Fault for {transaction_id}. {cond_code}. {progress}")
-
-    def abandoned_indication(
-        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
-    ):
-        logger.info(f"Indication: Abandoned for {transaction_id}. {cond_code}. {progress}")
-
-    def eof_recv_indication(self, transaction_id: TransactionId):
-        logger.info(f"Indication: EOF Recv for {transaction_id}")

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -70,12 +70,12 @@ class EdlService(Service):
         )
         self._node_flasher_service = node_flasher_service
 
-        self._put_req_queue = SimpleQueue()  # send new put reqs from the sat
+        self.put_req_queue = SimpleQueue()  # send new put requests from here
         self._cfdp_tm_queue = SimpleQueue()  # send telemetry pdus from here
         self._cfdp_src_queue = SimpleQueue()  # send tc for the source here
         self._cfdp_dest_queue = SimpleQueue()  # send tc for the dest here
-        self.cfdp_source_handler = None
-        self.cfdp_dest_handler = None
+        self._cfdp_source_handler = None
+        self._cfdp_dest_handler = None
 
         self.GND_ID = ByteFieldU8(0)
         self.SAT_ID = ByteFieldU8(1)
@@ -93,9 +93,20 @@ class EdlService(Service):
         self._edl_rejected_count_obj = edl_rec["rejected_count"]
         self._last_edl_obj = edl_rec["last_timestamp"]
 
+    def __del__(self) -> None:
+        # redefinition of the service destructor to handle the cfdp threads
+        if not self._event.is_set():
+            self._event.set()
+
+        if self._cfdp_source_handler.is_alive():
+            self._thread.join()
+        if self._cfdp_dest_handler.is_alive():
+            self._thread.join()
+
+        if self._thread.is_alive():
+            self._thread.join()
+
     def _init_cfdp(self, fwrite_cache: CacheStore) -> None:
-
-
         remote_entities = RemoteEntityConfigTable(
             [
                 RemoteEntityConfig(
@@ -112,25 +123,27 @@ class EdlService(Service):
                 ),
             ]
         )
-        self.cfdp_source_handler = SourceEntityHandler(
-            self._put_req_queue,
+        self._cfdp_source_handler = SourceEntityHandler(
+            self.put_req_queue,
             self._cfdp_src_queue,
             self._cfdp_tm_queue,
-            self.fwrite_cache,
+            fwrite_cache,
             remote_entities,
-            self.gnd_id,
-            self.sat_id,
-            self.stop_signal
+            self.GND_ID,
+            self.SAT_ID,
+            self._event
         )
-        self.cfdp_dest_handler = DestEntityHandler(
-            self._put_req_queue,
+        self._cfdp_dest_handler = DestEntityHandler(
+            self.put_req_queue,
             self._cfdp_dest_queue,
             self._cfdp_tm_queue,
-            self.fwrite_cache,
+            fwrite_cache,
             remote_entities,
-            self.sat_id,
-            self.stop_signal
+            self.SAT_ID,
+            self._event
         )
+        self._cfdp_source_handler.start()
+        self._cfdp_dest_handler.start()
 
     @property
     def _hmac_key(self) -> bytes:
@@ -222,15 +235,14 @@ class EdlService(Service):
             req_packet = None
 
         if req_packet is not None:
-            self._handle_pdu(req_packet)
+            self._handle_pdu(req_packet.payload)
 
         while not self._cfdp_tm_queue.empty():
             next_tm = self._cfdp_tm_queue.get(False)
-            self._respond(EdlVcid.FILE_TRANSFER, next_tm)
+            self._respond(EdlVcid.FILE_TRANSFER, next_tm.pdu)
 
     def _handle_pdu(self, pdu: AbstractFileDirectiveBase):
         packet_dest = get_packet_destination(pdu)
-        logger.debug(f"UDP server: Routing {pdu} to {packet_dest}")
         if packet_dest == PacketDestination.DEST_HANDLER:
             self._cfdp_dest_queue.put(pdu)
         elif packet_dest == PacketDestination.SOURCE_HANDLER:

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -152,7 +152,7 @@ class EdlService(Service):
             fwrite_cache,
             remote_entities,
             self.SAT_ID,
-            self._event
+            self._event,
         )
         self._cfdp_source_handler.start()
         self._cfdp_dest_handler.start()

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -81,7 +81,6 @@ class EdlService(Service):
         self.SAT_ID = ByteFieldU8(1)
         self._init_cfdp(node.fwrite_cache)
 
-
         # objs
         edl_rec = node.od["edl"]
         tx_rec = node.od["tx_control"]

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -1,5 +1,6 @@
 """'EDL Service"""
 
+from pathlib import Path
 from queue import Empty, SimpleQueue
 from time import time
 from typing import Any, Optional, Union
@@ -17,6 +18,7 @@ from spacepackets.cfdp import (
     TransmissionMode,
 )
 from spacepackets.cfdp.pdu import AbstractFileDirectiveBase
+from spacepackets.seqcount import FileSeqCountProvider
 from spacepackets.uslp import TransferFrame
 from spacepackets.util import ByteFieldU8
 
@@ -79,7 +81,11 @@ class EdlService(Service):
 
         self.GND_ID = ByteFieldU8(0)
         self.SAT_ID = ByteFieldU8(1)
-        self._init_cfdp(node.fwrite_cache)
+        self._cfdp_src_seq_num = FileSeqCountProvider(
+            16,
+            Path(node.work_base_dir + "/cfdp_src_seq.txt")
+        )
+        self._init_cfdp(node.fwrite_cache, self._cfdp_src_seq_num)
 
         # objs
         edl_rec = node.od["edl"]
@@ -105,7 +111,7 @@ class EdlService(Service):
         if self._thread.is_alive():
             self._thread.join()
 
-    def _init_cfdp(self, fwrite_cache: CacheStore) -> None:
+    def _init_cfdp(self, fwrite_cache: CacheStore, src_seq_num: FileSeqCountProvider) -> None:
         remote_entities = RemoteEntityConfigTable(
             [
                 RemoteEntityConfig(
@@ -124,6 +130,7 @@ class EdlService(Service):
                 ),
             ]
         )
+
         self._cfdp_source_handler = SourceEntityHandler(
             self.put_req_queue,
             self._cfdp_src_queue,
@@ -132,7 +139,8 @@ class EdlService(Service):
             remote_entities,
             self.GND_ID,
             self.SAT_ID,
-            self._event
+            self._event,
+            src_seq_num,
         )
         self._cfdp_dest_handler = DestEntityHandler(
             self.put_req_queue,

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -100,11 +100,15 @@ class EdlService(Service):
         )
         self._node_flasher_service = node_flasher_service
 
-        self._cfdp_tm_queue = SimpleQueue()  # send telemetry pdus from here.
-        self._cfdp_src_queue = SimpleQueue()  # send tc for the source here.
-        self._cfdp_dest_queue = SimpleQueue()  # send tc for the dest here.
+        self._put_req_queue = SimpleQueue()  # send new put reqs from the sat
+        self._cfdp_tm_queue = SimpleQueue()  # send telemetry pdus from here
+        self._cfdp_src_queue = SimpleQueue()  # send tc for the source here
+        self._cfdp_dest_queue = SimpleQueue()  # send tc for the dest here
         self.cfdp_source_handler = None
         self.cfdp_dest_handler = None
+
+        self.GND_ID = ByteFieldU8(0)
+        self.SAT_ID = ByteFieldU8(1)
 
         self._file_receiver = EdlFileReciever(node.fwrite_cache)
 
@@ -120,15 +124,12 @@ class EdlService(Service):
         self._last_edl_obj = edl_rec["last_timestamp"]
 
     def _init_cfdp(self) -> None:
-        GND_ID = ByteFieldU8(0)
-        SAT_ID = ByteFieldU8(1)
 
-        put_req_queue = SimpleQueue()
 
         remote_entities = RemoteEntityConfigTable(
             [
                 RemoteEntityConfig(
-                    entity_id=GND_ID,
+                    entity_id=self.GND_ID,
                     max_file_segment_len=None,
                     # FIXME this value should come from EdlPacket but EdlPacket does not define it.
                     # How does the exact value get determined? Currently it's just a mirror of the
@@ -142,9 +143,22 @@ class EdlService(Service):
             ]
         )
 
-        self.cfdp_source_handler = SourceEntityHandler(put_req_queue, self._cfdp_src_queue, self._cfdp_tm_queue,remote_entities, GND_ID, SAT_ID)
+        self.cfdp_source_handler = SourceEntityHandler(
+            self.put_req_queue,
+            self._cfdp_src_queue,
+            self._cfdp_tm_queue,
+            remote_entities,
+            self.GND_ID,
+            self.SAT_ID
+        )
 
-        self.cfdp_dest_handler = DestEntityHandler(put_req_queue, self._cfdp_dest_queue, self._cfdp_tm_queue,remote_entities, SAT_ID)
+        self.cfdp_dest_handler = DestEntityHandler(
+            self.put_req_queue,
+            self._cfdp_dest_queue,
+            self._cfdp_tm_queue,
+            remote_entities,
+            self.SAT_ID
+        )
 
     @property
     def _hmac_key(self) -> bytes:

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -125,7 +125,7 @@ class EdlService(Service):
                     # How does the exact value get determined? Currently it's just a mirror of the
                     # value in edl_file_upload.py
                     max_packet_len=950,
-                    closure_requested=False,
+                    closure_requested=True,
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
                     crc_type=ChecksumType.MODULAR,  # Yamcs only supports the legacy modular crc.

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -123,7 +123,7 @@ class EdlService(Service):
         self._edl_rejected_count_obj = edl_rec["rejected_count"]
         self._last_edl_obj = edl_rec["last_timestamp"]
 
-    def _init_cfdp(self) -> None:
+    def _init_cfdp(self, fwrite_cache: CacheStore) -> None:
 
 
         remote_entities = RemoteEntityConfigTable(
@@ -147,6 +147,7 @@ class EdlService(Service):
             self.put_req_queue,
             self._cfdp_src_queue,
             self._cfdp_tm_queue,
+            fwrite_cache,
             remote_entities,
             self.GND_ID,
             self.SAT_ID
@@ -156,6 +157,7 @@ class EdlService(Service):
             self.put_req_queue,
             self._cfdp_dest_queue,
             self._cfdp_tm_queue,
+            fwrite_cache,
             remote_entities,
             self.SAT_ID
         )

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -49,7 +49,12 @@ from spacepackets.uslp import TransferFrame
 from spacepackets.util import ByteFieldU8
 
 from ..protocols.cachestore import CacheStore
-from ..protocols.cfdp import FixedDestHandler, VfsSourceHandler
+from ..protocols.cfdp import (
+    DestEntityHandler,
+    FixedDestHandler,
+    SourceEntityHandler,
+    VfsSourceHandler,
+)
 from ..protocols.edl_command import (
     EdlCommandCode,
     EdlCommandError,
@@ -95,6 +100,12 @@ class EdlService(Service):
         )
         self._node_flasher_service = node_flasher_service
 
+        self._cfdp_tm_queue = SimpleQueue()  # send telemetry pdus from here.
+        self._cfdp_src_queue = SimpleQueue()  # send tc for the source here.
+        self._cfdp_dest_queue = SimpleQueue()  # send tc for the dest here.
+        self.cfdp_source_handler = None
+        self.cfdp_dest_handler = None
+
         self._file_receiver = EdlFileReciever(node.fwrite_cache)
 
         # objs
@@ -107,6 +118,33 @@ class EdlService(Service):
         self._edl_sequence_count_obj = edl_rec["sequence_count"]
         self._edl_rejected_count_obj = edl_rec["rejected_count"]
         self._last_edl_obj = edl_rec["last_timestamp"]
+
+    def _init_cfdp(self) -> None:
+        GND_ID = ByteFieldU8(0)
+        SAT_ID = ByteFieldU8(1)
+
+        put_req_queue = SimpleQueue()
+
+        remote_entities = RemoteEntityConfigTable(
+            [
+                RemoteEntityConfig(
+                    entity_id=GND_ID,
+                    max_file_segment_len=None,
+                    # FIXME this value should come from EdlPacket but EdlPacket does not define it.
+                    # How does the exact value get determined? Currently it's just a mirror of the
+                    # value in edl_file_upload.py
+                    max_packet_len=950,
+                    closure_requested=False,
+                    crc_on_transmission=False,
+                    default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
+                    crc_type=ChecksumType.MODULAR,
+                ),
+            ]
+        )
+
+        self.cfdp_source_handler = SourceEntityHandler(put_req_queue, self._cfdp_src_queue, self._cfdp_tm_queue,remote_entities, GND_ID, SAT_ID)
+
+        self.cfdp_dest_handler = DestEntityHandler(put_req_queue, self._cfdp_dest_queue, self._cfdp_tm_queue,remote_entities, SAT_ID)
 
     @property
     def _hmac_key(self) -> bytes:

--- a/oresat_c3/services/radios.py
+++ b/oresat_c3/services/radios.py
@@ -290,6 +290,7 @@ class UHFRadio(Radio):
         self._uhf_tot_ok_gpio = request_gpio_input("/dev/gpiochip0", 25, "UHF_TOT_OK")
         self._uhf_tot_clear_gpio = request_gpio_output("/dev/gpiochip0", 26, "UHF_TOT_CLEAR")
         self._uhf_enable_gpio = request_gpio_output("/dev/gpiochip0", 16, "UHF_ENABLE")
+        self._uhf_enable_pa = request_gpio_output("/dev/gpiochip0", 27, "UHF_PA_ENABLE")
 
     def enable(self):
         """
@@ -300,6 +301,7 @@ class UHFRadio(Radio):
         The radio power domain must be enabled first.
         """
         self._uhf_enable_gpio.set_value(self._uhf_enable_gpio.offsets[0], Value.ACTIVE)
+        self._uhf_enable_pa.set_value(self._uhf_enable_pa.offsets[0], Value.ACTIVE)
         time.sleep(0.1)
 
         # clear timeout timer
@@ -308,6 +310,7 @@ class UHFRadio(Radio):
     def disable(self):
         """Disable the UHF power domain."""
         self._uhf_enable_gpio.set_value(self._uhf_enable_gpio.offsets[0], Value.INACTIVE)
+        self._uhf_enable_pa.set_value(self._uhf_enable_pa.offsets[0], Value.INACTIVE)
         time.sleep(0.1)
 
     def is_rf_ok(self) -> bool:

--- a/tests/protocols/test_cachestore.py
+++ b/tests/protocols/test_cachestore.py
@@ -232,7 +232,7 @@ class TestCacheStore(unittest.TestCase):
             FilestoreResult.NOT_PERFORMED,
         )
 
-    def test_list_directory(self): #FIXME: need to write new test for this.
+    def test_list_directory(self):  # FIXME: need to write new test for this.
         """Test list_directory()"""
         self.cache.create_file(Path("c3_dir_111.txt"))
         cmd = ["ls", "-al"]

--- a/tests/protocols/test_cachestore.py
+++ b/tests/protocols/test_cachestore.py
@@ -1,5 +1,6 @@
 """Tests CacheStore"""
 
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -233,18 +234,24 @@ class TestCacheStore(unittest.TestCase):
 
     def test_list_directory(self): #FIXME: need to write new test for this.
         """Test list_directory()"""
+        self.cache.create_file(Path("c3_dir_111.txt"))
+        cmd = ["ls", "-al"]
+        result = subprocess.run(cmd, check=True, capture_output=True, cwd=self.cache._dir)
+        result = result.stdout.decode()
+
         dirlist_111 = Path(self.cache._dir, "c3_dir_111.txt")
         self.assertEqual(self.cache.list_directory(Path(), dirlist_111), FilestoreResult.SUCCESS)
         self.assertTrue(self.cache.file_exists(dirlist_111))
         with open(dirlist_111) as f:
-            self.assertCountEqual(f.read().split(), {self.exists.name, dirlist_111.name})
+            self.assertEqual(f.read(), result)
 
         self.assertEqual(self.cache.create_file(self.doesnt), FilestoreResult.CREATE_SUCCESS)
+        self.cache.create_file(Path("c3_dir_222.txt"))
+        result = subprocess.run(cmd, check=True, capture_output=True, cwd=self.cache._dir)
+        result = result.stdout.decode()
+
         dirlist_222 = Path(self.cache._dir, "c3_dir_222.txt")
         self.assertEqual(self.cache.list_directory(Path(), dirlist_222), FilestoreResult.SUCCESS)
         self.assertTrue(self.cache.file_exists(dirlist_222))
         with open(dirlist_222) as f:
-            self.assertCountEqual(
-                f.read().split(),
-                {self.exists.name, dirlist_111.name, self.doesnt.name, dirlist_222.name},
-            )
+            self.assertEqual(f.read(), result)

--- a/tests/protocols/test_cachestore.py
+++ b/tests/protocols/test_cachestore.py
@@ -231,12 +231,8 @@ class TestCacheStore(unittest.TestCase):
             FilestoreResult.NOT_PERFORMED,
         )
 
-    def test_list_directory(self):
+    def test_list_directory(self): #FIXME: need to write new test for this.
         """Test list_directory()"""
-        self.assertEqual(
-            self.cache.list_directory(Path(), self.invalid), FilestoreResult.NOT_PERFORMED
-        )
-
         dirlist_111 = Path(self.cache._dir, "c3_dir_111.txt")
         self.assertEqual(self.cache.list_directory(Path(), dirlist_111), FilestoreResult.SUCCESS)
         self.assertTrue(self.cache.file_exists(dirlist_111))

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -476,28 +476,28 @@ class TestCfdp(unittest.TestCase):
 
 
     def _src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:
-        pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get())
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get().pack())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_dest_queue.put(pdu)
         if delay > 0:
             time.sleep(delay)
 
     def _dest_gnd_to_sc_src(self, delay: float, expected_type: ABCMeta) -> None:
-        pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get())
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get().pack())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_src_queue.put(pdu)
         if delay > 0:
             time.sleep(delay)
 
     def _src_sc_to_gnd_dest(self, delay: float, expected_type: ABCMeta) -> None:
-        pdu = PduFactory.from_raw(self._cfdp_tm_queue.get())
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue.get().pack())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_dest_queue_gnd.put(pdu)
         if delay > 0:
             time.sleep(delay)
 
     def _dest_sc_to_gnd_src(self, delay: float, expected_type: ABCMeta) -> None:
-        pdu = PduFactory.from_raw(self._cfdp_tm_queue.get())
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue.get().pack())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_src_queue_gnd.put(pdu)
         if delay > 0:

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -28,6 +28,7 @@ from cfdppy.user import (
     TransactionFinishedParams,
     TransactionParams,
 )
+from spacepackets.cfdp import CfdpLv
 from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransactionId, TransmissionMode
 from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu, PduFactory
 from spacepackets.cfdp.tlv import (
@@ -36,8 +37,10 @@ from spacepackets.cfdp.tlv import (
     OriginatingTransactionId,
     ProxyMessageType,
     ProxyPutRequest,
+    ProxyPutRequestParams,
     ProxyPutResponse,
     ProxyPutResponseParams,
+    ProxyTransmissionMode,
 )
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
@@ -370,12 +373,25 @@ class TestCfdp(unittest.TestCase):
         # gnd_src --> s/c_dst Finished      T3
         # gnd_src <-- s/c_dst Ack (Fin)     T3
 
-        put = ProxyPutRequest(
-            destination_id=self.gnd_id,
-            source_file=Path(self.file.name),
-            dest_file=Path(self.file.name),
+
+        proxy_put = ProxyPutRequest(
+            ProxyPutRequestParams(
+                dest_entity_id=self.gnd_id,
+                source_file_name=CfdpLv.from_str(self.file.name),
+                dest_file_name=CfdpLv.from_str(self.file.name)
+            )
+        ).to_generic_msg_to_user_tlv()
+        # Yamcs will always send a proxy transmission mode message, for both class 1 or class 2.
+        proxy_trans = ProxyTransmissionMode(
+            TransmissionMode.ACKNOWLEDGED
+        ).to_generic_msg_to_user_tlv()
+        put = PutRequest(
+            destination_id=self.sat_id,
+            source_file=None,
+            dest_file=None,
             trans_mode=None,
             closure_requested=True,
+            msgs_to_user=[proxy_put, proxy_trans],
         )
 
         self._put_req_queue_gnd.put(put)
@@ -389,6 +405,7 @@ class TestCfdp(unittest.TestCase):
 
         # gnd_src --> s/c_dst Eof           T1
         time.sleep(0.15)
+        print("\n\n\na\n\n\n")
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
         print(get_packet_destination(pdu.pdu))
@@ -397,6 +414,7 @@ class TestCfdp(unittest.TestCase):
 
         # gnd_src <-- s/c_dst Ack (EoF)     T1
         time.sleep(0.15)
+        print("\n\n\nb\n\n\n")
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         pdu_packed = self._cfdp_tm_queue.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
@@ -405,6 +423,7 @@ class TestCfdp(unittest.TestCase):
 
         # gnd_src <-- s/c_dst Finished      T1
         time.sleep(0.15)
+        print("\n\n\nc\n\n\n")
         pdu_packed = self._cfdp_tm_queue.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
         self.assertIsInstance(pdu.pdu, FinishedPdu)
@@ -421,6 +440,102 @@ class TestCfdp(unittest.TestCase):
         # End of transaction 1. The queues used for it should be empty, as the next transactions
         # use the opposite queues.
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        print("\n\n\nDONE WITH TRANSACTION 1\n\n\n")
+
+        # gnd_src --> s/c_dst Metadata      T2
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, MetadataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # gnd_src --> s/c_dst Metadata      T2
+        time.sleep(0.2)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FileDataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # gnd_src --> s/c_dst Eof           T2
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(get_packet_destination(pdu.pdu))
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # gnd_src <-- s/c_dst Ack (EoF)     T2
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+
+        # gnd_src <-- s/c_dst Finished      T2
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+
+        # gnd_src --> s/c_dst Ack (Fin)     T2
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+        time.sleep(1)
+        # End of transaction 2.
+        print("\n\n\nDONE WITH TRANSACTION 2\n\n\n")
+
+
+        # gnd_src --> s/c_dst Metadata      T3
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, MetadataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # gnd_src --> s/c_dst Metadata      T3
+        time.sleep(0.2)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FileDataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # gnd_src --> s/c_dst Eof           T3
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(get_packet_destination(pdu.pdu))
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # gnd_src <-- s/c_dst Ack (EoF)     T3
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+
+        # gnd_src <-- s/c_dst Finished      T3
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+
+        # gnd_src --> s/c_dst Ack (Fin)     T3
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+        time.sleep(1)
+        # End of transaction 3.
+
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -30,6 +30,15 @@ from cfdppy.user import (
 )
 from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransactionId, TransmissionMode
 from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu, PduFactory
+from spacepackets.cfdp.tlv import (
+    DirectoryListingResponse,
+    DirectoryOperationMessageType,
+    OriginatingTransactionId,
+    ProxyMessageType,
+    ProxyPutRequest,
+    ProxyPutResponse,
+    ProxyPutResponseParams,
+)
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
@@ -168,13 +177,12 @@ class TestCfdp(unittest.TestCase):
     def test_simple_transfer(self):
         """A basic transfer that ensures the no-loss path is working"""
         # The simple standard file transfer
-        # src --> Metadata
-        # src --> FileData
-        # src --> EoF
-        # dst <-- Ack (EoF)
-        # dst <-- Finished
-        # src --> Ack (Finished)
-        # pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
+        # src --> dst Metadata
+        # src --> dst FileData
+        # src --> dst EoF
+        # src <-- dst Ack (EoF)
+        # src <-- dst Finished
+        # src --> dst Ack (Finished)
 
         put = put_request(self.sat_id, self.file.name)
 
@@ -241,6 +249,7 @@ class TestCfdp(unittest.TestCase):
 
     # Broken for now. For some reason CFDP stops resending EOFs after recieving a finished PDU,
     # leaving it stuck waiting for an ACK (EOF) without resending EOFs.
+    # @unittest.skip("FIXME: stops resending EoFs after recieving finished")
     def test_dropped_ack(self):
         """What happens if the first ack gets dropped?"""
         # src --> Metadata
@@ -262,6 +271,7 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.2)
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
         self.assertIsInstance(pdu.pdu, MetadataPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
@@ -269,6 +279,7 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.15)
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
         self.assertIsInstance(pdu.pdu, FileDataPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
@@ -276,7 +287,7 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.15)
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(get_packet_destination(pdu.pdu))
+        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
         self.assertIsInstance(pdu.pdu, EofPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
@@ -284,6 +295,8 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
 
         # dst <-- Finished
         time.sleep(0.15)
@@ -331,63 +344,95 @@ class TestCfdp(unittest.TestCase):
             source.TransactionStep.IDLE
         )
 
+    def test_proxy_put_request(self):
+        """
+        The ground asks the spacecraft to send a file to someone (the ground in our case), the
+        spacecraft creates a new transation to send it, then starts a transaction to send a
+        "we've finished" message.
+        """
+        # gnd_src --> s/c_dst Metadata      T1
+        # gnd_src --> s/c_dst Eof           T1
+        # gnd_src <-- s/c_dst Ack (EoF)     T1
+        # gnd_src <-- s/c_dst Finished      T1
+        # gnd_src --> s/c_dst Ack (Fin)     T1
 
-    # @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
-    # def test_missing_ack(self):
-    #     """What happens if the first ack gets dropped?"""
-    #     # src --> Metadata
-    #     # src --> FileData
-    #     # src --> EoF
-    #     # dst  X  Ack (EoF)
-    #     # dst <-- Finished
-    #     # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
-    #     # src --> EoF
-    #     # dst <-- Ack (EoF)
-    #     # dst <-- Finished
-    #     # src --> Ack (Finished)
-    #     pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
+        # gnd_dst <-- s/c_src Metadata      T2
+        # gnd_dst <-- s/c_src Filedata      T2
+        # gnd_dst <-- s/c_src Eof           T2
+        # gnd_dst --> s/c_src Ack (EoF)     T2
+        # gnd_dst --> s/c_src Finished      T2
+        # gnd_dst <-- s/c_src Ack (Fin)     T2
 
-    #     put = put_request(self.dst_id, self.file.name)
-    #     self.assertTrue(self.src.put_request(put))
+        # Not entirely clear on how this is supposed to work.
+        # gnd_src <-- s/c_dst Metadata      T3
+        # gnd_src <-- s/c_dst Eof           T3
+        # gnd_src --> s/c_dst Ack (EoF)     T3
+        # gnd_src --> s/c_dst Finished      T3
+        # gnd_src <-- s/c_dst Ack (Fin)     T3
 
-    #     for i, pdutype in enumerate(pdus):
-    #         self.src.state_machine()
-    #         self.dst.state_machine()
+        put = ProxyPutRequest(
+            destination_id=self.gnd_id,
+            source_file=Path(self.file.name),
+            dest_file=Path(self.file.name),
+            trans_mode=None,
+            closure_requested=True,
+        )
 
-    #         print("SRC:", self.src.step, "| DST:", self.src.step)
+        self._put_req_queue_gnd.put(put)
 
-    #         while self.src.packets_ready:
-    #             pdu = self.src.get_next_packet().pdu
-    #             print("\nSRC ", pdu, "\n")
-    #             self.assertIsInstance(pdu, pdutype)
-    #             self.dst.state_machine(pdu)
+        # gnd_src --> s/c_dst Metadata      T1
+        time.sleep(0.2)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, MetadataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
 
-    #         while self.dst.packets_ready:
-    #             pdu = self.dst.get_next_packet().pdu
-    #             self.assertIsInstance(pdu, pdutype)
-    #             if i == 3:  # Skip first Ack
-    #                 break
-    #             print("\nSRC ", pdu, "\n")
-    #             with self.assertRaises(PduIgnoredForSource):
-    #                 self.src.state_machine(pdu)
+        # gnd_src --> s/c_dst Eof           T1
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(get_packet_destination(pdu.pdu))
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
 
-    #     self.src.state_machine()
-    #     self.dst.state_machine()
+        # gnd_src <-- s/c_dst Ack (EoF)     T1
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
 
-    #     self.assertEqual(self.src.step, source.TransactionStep.IDLE)
-    #     self.assertEqual(self.dst.step, dest.TransactionStep.IDLE)
+        # gnd_src <-- s/c_dst Finished      T1
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
 
+        # gnd_src --> s/c_dst Ack (Fin)     T1
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+        time.sleep(1)
+        # End of transaction 1. The queues used for it should be empty, as the next transactions
+        # use the opposite queues.
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
 
-#
-#
-#
-#    def run(self):
-#        while packet := self.downlink.get():
-#            with self.lock:
-#                self.src.state_machine(packet)
-#                self.src.state_machine()
-#                while self.src.packets_ready:
-#                    pdu = self.src.get_next_packet().pdu
-#                    self.uplink.put(pdu)
-#
+        # Make sure we've returned to idle / empty.
+        time.sleep(1)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler_gnd.source_handler.step,
+            source.TransactionStep.IDLE
+        )
 

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -49,6 +49,8 @@ def put_request(destination: ByteFieldU8, file_path: str) -> PutRequest:
 
 
 class TestCfdp(unittest.TestCase):
+    TIMEOUT_DUR = 0.6
+
     def setUp(self):
         self.sat_file = Path("c3_tmp_123")
         self.cachedir = TemporaryDirectory()
@@ -82,6 +84,8 @@ class TestCfdp(unittest.TestCase):
                     max_packet_len=950,
                     closure_requested=True,
                     crc_on_transmission=False,
+                    positive_ack_timer_interval_seconds=self.TIMEOUT_DUR,
+                    nak_timer_interval_seconds=self.TIMEOUT_DUR,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
                     crc_type=ChecksumType.MODULAR,
                 ),
@@ -121,6 +125,8 @@ class TestCfdp(unittest.TestCase):
                     max_packet_len=950,
                     closure_requested=True,
                     crc_on_transmission=False,
+                    positive_ack_timer_interval_seconds=self.TIMEOUT_DUR,
+                    nak_timer_interval_seconds=self.TIMEOUT_DUR,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
                     crc_type=ChecksumType.MODULAR,
                 ),
@@ -196,6 +202,7 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
             self.cfdp_source_handler_gnd.source_handler.step,
@@ -255,6 +262,7 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
             self.cfdp_source_handler_gnd.source_handler.step,
@@ -358,6 +366,7 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
             self.cfdp_source_handler_gnd.source_handler.step,
@@ -462,6 +471,7 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
             self.cfdp_source_handler_gnd.source_handler.step,
@@ -475,7 +485,10 @@ class TestCfdp(unittest.TestCase):
         self.cache_gnd.delete_file(Path(dir_listing_gnd))
 
     def test_timed_out(self):
-        """src never hears acks"""
+        """
+        After the first 3 PDUs, stop transfering pdus. This lets us test both the source and the
+        dest timing out.
+        """
         # src --> Metadata
         # src --> FileData
         # src --> EoF
@@ -485,7 +498,6 @@ class TestCfdp(unittest.TestCase):
         # src --> EoF
         # timeout
         # Transaction Ended
-
         put = put_request(self.sat_id, self.gnd_file.name)
         self._put_req_queue_gnd.put(put)
         time.sleep(0.2)
@@ -497,7 +509,56 @@ class TestCfdp(unittest.TestCase):
         # src --> EoF
         self._src_gnd_to_sc_dest(0.15, EofPdu)
 
-        time.sleep(1000)
+        self._cfdp_tm_queue.get() # drop the ack(eof)
+        self._cfdp_tm_queue.get() # drop the fin
+        self.assertEqual(
+            self.cfdp_source_handler_gnd.source_handler.step,
+            source.TransactionStep.WAITING_FOR_EOF_ACK
+        )
+        self.assertEqual(
+            self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.WAITING_FOR_FINISHED_ACK
+        )
+        time.sleep(self.TIMEOUT_DUR + 0.02)
+
+        pdu = self._cfdp_tm_queue_gnd.get()
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        pdu = self._cfdp_tm_queue.get()
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        time.sleep(self.TIMEOUT_DUR + 0.02)
+
+        pdu = self._cfdp_tm_queue_gnd.get()
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        pdu = self._cfdp_tm_queue.get()
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(
+            self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.WAITING_FOR_FINISHED_ACK
+        )
+        time.sleep(self.TIMEOUT_DUR + 0.02)
+
+        # think it should crash here.
+        pdu = self._cfdp_tm_queue_gnd.get()
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        pdu = self._cfdp_tm_queue.get()
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        time.sleep(self.TIMEOUT_DUR + 0.02)
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(
+            self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE
+        )
+        time.sleep(self.TIMEOUT_DUR * 2 + 0.02)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)
@@ -507,16 +568,12 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
             self.cfdp_source_handler_gnd.source_handler.step,
             source.TransactionStep.IDLE
         )
-        self.assertEqual(
-            self.cache.read_data(self.gnd_file),
-            self.cache_gnd.read_data(self.gnd_file, None)
-        )
-        self.cache.delete_file(self.gnd_file)
 
     def _src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:
         pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get().pack())

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -165,7 +165,6 @@ class TestCfdp(unittest.TestCase):
         self.cfdp_dest_handler.join()
         self.cfdp_source_handler_gnd.join()
         self.cfdp_dest_handler_gnd.join()
-        self.file.close()
 
     def test_simple_transfer(self):
         """A basic transfer that ensures the no-loss path is working"""
@@ -394,6 +393,7 @@ class TestCfdp(unittest.TestCase):
         # this is put into the working directory. This is awful and should be fixed, but that would
         # require breaking cachestore even more.
         dir_listing_gnd = ".dirlist.notsaved"
+        dir_listing_sc = "c3_dirlist_0"
         dir_req = DirectoryListingRequest(
             DirectoryParams(
                 dir_path=CfdpLv.from_str(""), dir_file_name=CfdpLv.from_str(dir_listing_gnd)
@@ -458,10 +458,10 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler_gnd.source_handler.step, source.TransactionStep.IDLE
         )
         self.assertEqual(
-            self.cache.read_data(Path(dir_listing_gnd)),
+            self.cache.read_data(Path(dir_listing_sc)),
             self.cache_gnd.read_data(Path(dir_listing_gnd), None),
         )
-        self.cache.delete_file(Path(dir_listing_gnd))
+        self.cache.delete_file(Path(dir_listing_sc))
         self.cache_gnd.delete_file(Path(dir_listing_gnd))
 
     def test_timed_out(self):

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -170,11 +170,11 @@ class TestCfdp(unittest.TestCase):
         self.cfdp_dest_handler_gnd.start()
 
     def tearDown(self):
+        self.stop_signal.set()
         self.cfdp_source_handler.join()
         self.cfdp_dest_handler.join()
         self.cfdp_source_handler_gnd.join()
         self.cfdp_dest_handler_gnd.join()
-        self.stop_signal.set()
         self.file.close()
 
     def test_simple_transfer(self):

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -213,12 +213,12 @@ class TestCfdp(unittest.TestCase):
         # src --> FileData
         # src --> EoF
         # dst  X  Ack (EoF)
-        # dst <-- Finished
+        # dst --> Finished
         # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
         # src --> EoF
-        # dst <-- Finished # same timeout as the EOF, not acked so re-issued as well.
-        # dst <-- Ack (EoF)
-        # dst <-- Finished
+        # dst --> Finished # same timeout as the EOF, not acked so re-issued as well.
+        # dst --> Ack (EoF)
+        # dst --> Finished
         # src --> Ack (Finished)
 
         put = put_request(self.sat_id, self.gnd_file.name)
@@ -474,6 +474,49 @@ class TestCfdp(unittest.TestCase):
         self.cache.delete_file(Path(dir_listing_gnd))
         self.cache_gnd.delete_file(Path(dir_listing_gnd))
 
+    def test_timed_out(self):
+        """src never hears acks"""
+        # src --> Metadata
+        # src --> FileData
+        # src --> EoF
+        # timeout
+        # src --> EoF
+        # timeout
+        # src --> EoF
+        # timeout
+        # Transaction Ended
+
+        put = put_request(self.sat_id, self.gnd_file.name)
+        self._put_req_queue_gnd.put(put)
+        time.sleep(0.2)
+
+        # src --> Metadata
+        self._src_gnd_to_sc_dest(0.15, MetadataPdu)
+        # src --> Filedata
+        self._src_gnd_to_sc_dest(0.15, FileDataPdu)
+        # src --> EoF
+        self._src_gnd_to_sc_dest(0.15, EofPdu)
+
+        time.sleep(1000)
+
+        # Make sure we've returned to idle / empty.
+        time.sleep(1)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler_gnd.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(
+            self.cache.read_data(self.gnd_file),
+            self.cache_gnd.read_data(self.gnd_file, None)
+        )
+        self.cache.delete_file(self.gnd_file)
 
     def _src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:
         pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get().pack())

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -40,17 +40,6 @@ from oresat_c3.protocols.cachestore import CacheStore
 from oresat_c3.protocols.cfdp import DestEntityHandler, SourceEntityHandler
 
 
-class CountdownProvider(CheckTimerProvider):
-    """Copied from the cfdppy example.
-
-    I think this is to allow for custom timeouts based on latency between local and remote
-    entities? It doesn't set all the timers though, ACK timer I'm looking at you.
-    """
-
-    def provide_check_timer(self, local_entity_id, remote_entity_id, entity_type) -> Countdown:
-        return Countdown(timedelta(seconds=5.0))
-
-
 def put_request(destination: ByteFieldU8, file_path: str) -> PutRequest:
     """Creates a simple PutRequest for the file in file_path"""
     return PutRequest(
@@ -71,8 +60,9 @@ class TestCfdp(unittest.TestCase):
         self.cache.write_data(self.sat_file, b"This is some example data\x01\x02\x03")
 
         self.cachedir_gnd = TemporaryDirectory()
-        self.cache_gnd = RestrictedFilestore(Path(self.cachedir_gnd.name))
         self.gnd_file = Path("c3_tmp_1234")
+        # A less restricted filestore than the oresat one, so that we don't have to break that more.
+        self.cache_gnd = RestrictedFilestore(Path(self.cachedir_gnd.name))
         self.cache_gnd.create_file(self.gnd_file)
         self.cache_gnd.write_data(self.gnd_file, b"This is some example data\x01\x02\x03", None)
 
@@ -216,13 +206,10 @@ class TestCfdp(unittest.TestCase):
         )
         self.assertEqual(
             self.cache.read_data(self.gnd_file),
-            self.cache_gnd.read_data(self.gnd_file)
+            self.cache_gnd.read_data(self.gnd_file, None)
         )
         self.cache.delete_file(self.gnd_file)
 
-    # Broken for now. For some reason CFDP stops resending EOFs after recieving a finished PDU,
-    # leaving it stuck waiting for an ACK (EOF) without resending EOFs.
-    # @unittest.skip("FIXME: stops resending EoFs after recieving finished")
     def test_dropped_ack(self):
         """What happens if the first ack gets dropped?"""
         # src --> Metadata
@@ -232,11 +219,12 @@ class TestCfdp(unittest.TestCase):
         # dst <-- Finished
         # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
         # src --> EoF
+        # dst <-- Finished # same timeout as the EOF, not acked so re-issued as well.
         # dst <-- Ack (EoF)
         # dst <-- Finished
         # src --> Ack (Finished)
 
-        put = put_request(self.sat_id, self.file.name)
+        put = put_request(self.sat_id, self.gnd_file.name)
         self._put_req_queue_gnd.put(put)
         time.sleep(0.2)
 
@@ -249,32 +237,18 @@ class TestCfdp(unittest.TestCase):
         # dst X-- Ack (EoF)
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self._cfdp_tm_queue.get() # drop the pdu
         # dst <-- Finished
         self._dest_sc_to_gnd_src(0.15, FinishedPdu)
-
-        print(self.cfdp_source_handler_gnd.source_handler.step)
-
+        # A timeout will occur here.
+        # src --> EoF
+        self._src_gnd_to_sc_dest(0.15, EofPdu)
+        # dst <-- Ack (EoF)
+        self._dest_sc_to_gnd_src(0.15, AckPdu)
         # dst <-- Finished
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FinishedPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-        time.sleep(1)
-
-        print(self.cfdp_source_handler_gnd.source_handler.step)
-
-        time.sleep(100)
-
+        self._dest_sc_to_gnd_src(0.15, FinishedPdu)
         # src --> Ack (Finished)
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue.empty())
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
+        self._src_gnd_to_sc_dest(0.15, AckPdu)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)
@@ -291,7 +265,7 @@ class TestCfdp(unittest.TestCase):
         )
         self.assertEqual(
             self.cache.read_data(self.gnd_file),
-            self.cache_gnd.read_data(self.gnd_file)
+            self.cache_gnd.read_data(self.gnd_file, None)
         )
         self.cache.delete_file(self.gnd_file)
 
@@ -394,7 +368,7 @@ class TestCfdp(unittest.TestCase):
         )
         self.assertEqual(
             self.cache.read_data(self.sat_file),
-            self.cache_gnd.read_data(self.sat_file)
+            self.cache_gnd.read_data(self.sat_file, None)
         )
         self.cache_gnd.delete_file(self.sat_file)
 

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -1,3 +1,5 @@
+import threading
+import time
 import unittest
 from datetime import timedelta
 from pathlib import Path
@@ -5,6 +7,7 @@ from queue import Empty, SimpleQueue
 from tempfile import NamedTemporaryFile
 from typing import Any
 
+from cfdppy import get_packet_destination
 from cfdppy.exceptions import PduIgnoredForSource
 from cfdppy.handler import dest, source
 from cfdppy.handler.dest import DestHandler
@@ -26,7 +29,7 @@ from cfdppy.user import (
     TransactionParams,
 )
 from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransactionId, TransmissionMode
-from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu
+from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu, PduFactory
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
@@ -45,82 +48,10 @@ class CountdownProvider(CheckTimerProvider):
         return Countdown(timedelta(seconds=5.0))
 
 
-class PrintFaults(DefaultFaultHandlerBase):
-    """Prints all faults to stdout"""
-
-    def notice_of_suspension_cb(self, transaction_id, cond, progress):
-        # print(f"Transaction {transaction_id} suspended: {cond}. Progress {progress}")
-        pass
-
-    def notice_of_cancellation_cb(self, transaction_id, cond, progress):
-        # print(f"Transaction {transaction_id} cancelled: {cond}. Progress {progress}")
-        pass
-
-    def abandoned_cb(self, transaction_id, cond, progress):
-        # print(f"Transaction {transaction_id} abandoned: {cond}. Progress {progress}")
-        pass
-
-    def ignore_cb(self, transaction_id, cond, progress):
-        # print(f"Transaction {transaction_id} ignored: {cond}. Progress {progress}")
-        pass
-
-
-class PrintUser(CfdpUserBase):
-    """Prints all indications to sdtout"""
-
-    def transaction_indication(self, transaction_indication_params: TransactionParams):
-        # print(f"Indication: Transaction. {transaction_indication_params}")
-        pass
-
-    def eof_sent_indication(self, transaction_id: TransactionId):
-        # print(f"Indication: EOF Sent for {transaction_id}.")
-        pass
-
-    def transaction_finished_indication(self, params: TransactionFinishedParams):
-        # print(f"Indication: Transaction Finished. {params}")
-        pass
-
-    def metadata_recv_indication(self, params: MetadataRecvParams):
-        # print(f"Indication: Metadata Recv. {params}")
-        pass
-
-    def file_segment_recv_indication(self, params: FileSegmentRecvdParams):
-        # print(f"Indication: File Segment Recv. {params}")
-        pass
-
-    def report_indication(self, transaction_id: TransactionId, status_report: Any):
-        # print("Indication: Report for {transaction_id}. {status_report}")
-        pass
-
-    def suspended_indication(self, transaction_id: TransactionId, cond_code: ConditionCode):
-        # print("Indication: Suspended for {transaction_id}. {cond_code}")
-        pass
-
-    def resumed_indication(self, transaction_id: TransactionId, progress: int):
-        # print("Indication: Resumed for {transaction_id}. {progress}")
-        pass
-
-    def fault_indication(
-        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
-    ):
-        # print("Indication: Fault for {transaction_id}. {cond_code}. {progress}")
-        pass
-
-    def abandoned_indication(
-        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
-    ):
-        # print("Indication: Abandoned for {transaction_id}. {cond_code}. {progress}")
-        pass
-
-    def eof_recv_indication(self, transaction_id: TransactionId):
-        # print("Indication: EOF Recv for {transaction_id}")
-        pass
-
-
-def put_request(dest: ByteFieldU8, file_path: str) -> PutRequest:
+def put_request(destination: ByteFieldU8, file_path: str) -> PutRequest:
     """Creates a simple PutRequest for the file in file_path"""
     return PutRequest(
-        destination_id=dest,
+        destination_id=destination,
         source_file=Path(file_path),
         dest_file=Path(file_path),
         trans_mode=None,
@@ -142,6 +73,7 @@ class TestCfdp(unittest.TestCase):
         self._cfdp_src_queue = SimpleQueue()
         self._cfdp_dest_queue = SimpleQueue()
         self._cfdp_tm_queue = SimpleQueue()
+        self.stop_signal = threading.Event()
 
         # Satellite handling
         remote_entities = RemoteEntityConfigTable(
@@ -166,14 +98,16 @@ class TestCfdp(unittest.TestCase):
             self._cfdp_tm_queue,
             remote_entities,
             self.gnd_id,
-            self.sat_id
+            self.sat_id,
+            self.stop_signal
         )
         self.cfdp_dest_handler = DestEntityHandler(
             self._put_req_queue,
             self._cfdp_dest_queue,
             self._cfdp_tm_queue,
             remote_entities,
-            self.sat_id
+            self.sat_id,
+            self.stop_signal
         )
 
         # Ground station handling
@@ -206,17 +140,29 @@ class TestCfdp(unittest.TestCase):
             self._cfdp_tm_queue_gnd,
             remote_entities_gnd,
             self.sat_id,
-            self.gnd_id
+            self.gnd_id,
+            self.stop_signal
         )
         self.cfdp_dest_handler_gnd = DestEntityHandler(
             self._put_req_queue_gnd,
             self._cfdp_dest_queue_gnd,
             self._cfdp_tm_queue_gnd,
             remote_entities_gnd,
-            self.gnd_id
+            self.gnd_id,
+            self.stop_signal
         )
 
+        self.cfdp_source_handler.start()
+        self.cfdp_dest_handler.start()
+        self.cfdp_source_handler_gnd.start()
+        self.cfdp_dest_handler_gnd.start()
+
     def tearDown(self):
+        self.cfdp_source_handler.join()
+        self.cfdp_dest_handler.join()
+        self.cfdp_source_handler_gnd.join()
+        self.cfdp_dest_handler_gnd.join()
+        self.stop_signal.set()
         self.file.close()
 
     def test_simple_transfer(self):
@@ -228,9 +174,64 @@ class TestCfdp(unittest.TestCase):
         # dst <-- Ack (EoF)
         # dst <-- Finished
         # src --> Ack (Finished)
-        pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
+        # pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
 
-        self.cfdp_source_handler_gnd
+        put = put_request(self.sat_id, self.file.name)
+
+        self._put_req_queue_gnd.put(put)
+
+        time.sleep(0.2)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, MetadataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FileDataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(get_packet_destination(pdu.pdu))
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        time.sleep(1)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler_gnd.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+
 
     # @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
     # def test_missing_ack(self):

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -2,14 +2,12 @@ import threading
 import time
 import unittest
 from abc import ABCMeta
-from datetime import timedelta
 from pathlib import Path
 from queue import SimpleQueue
 from tempfile import TemporaryDirectory
 
 from cfdppy.handler import dest, source
 from cfdppy.mib import (
-    CheckTimerProvider,
     RemoteEntityConfig,
     RemoteEntityConfigTable,
 )
@@ -23,7 +21,7 @@ from spacepackets.cfdp.pdu import (
     FileDataPdu,
     FinishedPdu,
     MetadataPdu,
-    NakPdu,
+    NakPdu,  # noqa: F401
     PduFactory,
 )
 from spacepackets.cfdp.tlv import (
@@ -33,7 +31,6 @@ from spacepackets.cfdp.tlv import (
     ProxyPutRequestParams,
     ProxyTransmissionMode,
 )
-from spacepackets.countdown import Countdown
 from spacepackets.util import ByteFieldU8
 
 from oresat_c3.protocols.cachestore import CacheStore

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -1,0 +1,287 @@
+import unittest
+from datetime import timedelta
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+from cfdppy.exceptions import PduIgnoredForSource
+from cfdppy.handler import dest, source
+from cfdppy.handler.dest import DestHandler
+from cfdppy.handler.source import SourceHandler
+from cfdppy.mib import (
+    CheckTimerProvider,
+    DefaultFaultHandlerBase,
+    IndicationConfig,
+    LocalEntityConfig,
+    RemoteEntityConfig,
+    RemoteEntityConfigTable,
+)
+from cfdppy.request import PutRequest
+from cfdppy.user import (
+    CfdpUserBase,
+    FileSegmentRecvdParams,
+    MetadataRecvParams,
+    TransactionFinishedParams,
+    TransactionParams,
+)
+from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransactionId, TransmissionMode
+from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu
+from spacepackets.countdown import Countdown
+from spacepackets.seqcount import SeqCountProvider
+from spacepackets.util import ByteFieldU8
+
+
+class CountdownProvider(CheckTimerProvider):
+    """Copied from the cfdppy example.
+
+    I think this is to allow for custom timeouts based on latency between local and remote
+    entities? It doesn't set all the timers though, ACK timer I'm looking at you.
+    """
+
+    def provide_check_timer(self, local_entity_id, remote_entity_id, entity_type) -> Countdown:
+        return Countdown(timedelta(seconds=5.0))
+
+
+class PrintFaults(DefaultFaultHandlerBase):
+    """Prints all faults to stdout"""
+
+    def notice_of_suspension_cb(self, transaction_id, cond, progress):
+        # print(f"Transaction {transaction_id} suspended: {cond}. Progress {progress}")
+        pass
+
+    def notice_of_cancellation_cb(self, transaction_id, cond, progress):
+        # print(f"Transaction {transaction_id} cancelled: {cond}. Progress {progress}")
+        pass
+
+    def abandoned_cb(self, transaction_id, cond, progress):
+        # print(f"Transaction {transaction_id} abandoned: {cond}. Progress {progress}")
+        pass
+
+    def ignore_cb(self, transaction_id, cond, progress):
+        # print(f"Transaction {transaction_id} ignored: {cond}. Progress {progress}")
+        pass
+
+
+class PrintUser(CfdpUserBase):
+    """Prints all indications to sdtout"""
+
+    def transaction_indication(self, transaction_indication_params: TransactionParams):
+        # print(f"Indication: Transaction. {transaction_indication_params}")
+        pass
+
+    def eof_sent_indication(self, transaction_id: TransactionId):
+        # print(f"Indication: EOF Sent for {transaction_id}.")
+        pass
+
+    def transaction_finished_indication(self, params: TransactionFinishedParams):
+        # print(f"Indication: Transaction Finished. {params}")
+        pass
+
+    def metadata_recv_indication(self, params: MetadataRecvParams):
+        # print(f"Indication: Metadata Recv. {params}")
+        pass
+
+    def file_segment_recv_indication(self, params: FileSegmentRecvdParams):
+        # print(f"Indication: File Segment Recv. {params}")
+        pass
+
+    def report_indication(self, transaction_id: TransactionId, status_report: Any):
+        # print("Indication: Report for {transaction_id}. {status_report}")
+        pass
+
+    def suspended_indication(self, transaction_id: TransactionId, cond_code: ConditionCode):
+        # print("Indication: Suspended for {transaction_id}. {cond_code}")
+        pass
+
+    def resumed_indication(self, transaction_id: TransactionId, progress: int):
+        # print("Indication: Resumed for {transaction_id}. {progress}")
+        pass
+
+    def fault_indication(
+        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
+    ):
+        # print("Indication: Fault for {transaction_id}. {cond_code}. {progress}")
+        pass
+
+    def abandoned_indication(
+        self, transaction_id: TransactionId, cond_code: ConditionCode, progress: int
+    ):
+        # print("Indication: Abandoned for {transaction_id}. {cond_code}. {progress}")
+        pass
+
+    def eof_recv_indication(self, transaction_id: TransactionId):
+        # print("Indication: EOF Recv for {transaction_id}")
+        pass
+
+
+def put_request(dest: ByteFieldU8, file_path: str) -> PutRequest:
+    """Creates a simple PutRequest for the file in file_path"""
+    return PutRequest(
+        destination_id=dest,
+        source_file=Path(file_path),
+        dest_file=Path(file_path),
+        trans_mode=None,
+        closure_requested=None,
+    )
+
+
+# @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
+class TestCfdp(unittest.TestCase):
+    def setUp(self):
+        self.file = NamedTemporaryFile()
+        self.file.write(b"This is some example data\x01\x02\x03")
+        self.file.flush()
+
+        self.src_id = ByteFieldU8(0)
+        self.dst_id = ByteFieldU8(1)
+
+        src_cfg = LocalEntityConfig(
+            local_entity_id=self.src_id,
+            indication_cfg=IndicationConfig(),
+            default_fault_handlers=PrintFaults(),
+        )
+
+        dst_cfg = LocalEntityConfig(
+            local_entity_id=self.dst_id,
+            indication_cfg=IndicationConfig(),
+            default_fault_handlers=PrintFaults(),
+        )
+
+        src_remote_entities = RemoteEntityConfigTable(
+            [
+                RemoteEntityConfig(
+                    entity_id=self.dst_id,
+                    max_file_segment_len=None,
+                    max_packet_len=950,
+                    closure_requested=False,
+                    crc_on_transmission=False,
+                    default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
+                    crc_type=ChecksumType.CRC_32,
+                ),
+            ]
+        )
+
+        dst_remote_entities = RemoteEntityConfigTable(
+            [
+                RemoteEntityConfig(
+                    entity_id=self.src_id,
+                    max_file_segment_len=None,
+                    max_packet_len=950,
+                    closure_requested=False,
+                    crc_on_transmission=False,
+                    default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
+                    crc_type=ChecksumType.CRC_32,
+                ),
+            ]
+        )
+
+        self.src = SourceHandler(
+            cfg=src_cfg,
+            user=PrintUser(),
+            remote_cfg_table=src_remote_entities,
+            check_timer_provider=CountdownProvider(),
+            seq_num_provider=SeqCountProvider(16),
+        )
+
+        self.dst = DestHandler(
+            cfg=dst_cfg,
+            user=PrintUser(),
+            remote_cfg_table=dst_remote_entities,
+            check_timer_provider=CountdownProvider(),
+        )
+
+    def tearDown(self):
+        self.file.close()
+
+    def test_simple_transfer(self):
+        """A basic transfer that ensures the no-loss path is working"""
+        # The simple standard file transfer
+        # src --> Metadata
+        # src --> FileData
+        # src --> EoF
+        # dst <-- Ack (EoF)
+        # dst <-- Finished
+        # src --> Ack (Finished)
+        pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
+
+        put = put_request(self.dst_id, self.file.name)
+        self.assertTrue(self.src.put_request(put))
+
+        for pdutype in pdus:
+            self.src.state_machine()
+            self.dst.state_machine()
+
+            while self.src.packets_ready:
+                pdu = self.src.get_next_packet().pdu
+                self.assertIsInstance(pdu, pdutype)
+                self.dst.state_machine(pdu)
+
+            while self.dst.packets_ready:
+                pdu = self.dst.get_next_packet().pdu
+                self.assertIsInstance(pdu, pdutype)
+                self.src.state_machien(pdu)
+
+        self.src.state_machine()
+        self.dst.state_machine()
+
+        self.assertEqual(self.src.step, source.TransactionStep.IDLE)
+        self.assertEqual(self.dst.step, dest.TransactionStep.IDLE)
+
+    @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
+    def test_missing_ack(self):
+        """What happens if the first ack gets dropped?"""
+        # src --> Metadata
+        # src --> FileData
+        # src --> EoF
+        # dst  X  Ack (EoF)
+        # dst <-- Finished
+        # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
+        # src --> EoF
+        # dst <-- Ack (EoF)
+        # dst <-- Finished
+        # src --> Ack (Finished)
+        pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
+
+        put = put_request(self.dst_id, self.file.name)
+        self.assertTrue(self.src.put_request(put))
+
+        for i, pdutype in enumerate(pdus):
+            self.src.state_machine()
+            self.dst.state_machine()
+
+            print("SRC:", self.src.step, "| DST:", self.src.step)
+
+            while self.src.packets_ready:
+                pdu = self.src.get_next_packet().pdu
+                print("\nSRC ", pdu, "\n")
+                self.assertIsInstance(pdu, pdutype)
+                self.dst.state_machine(pdu)
+
+            while self.dst.packets_ready:
+                pdu = self.dst.get_next_packet().pdu
+                self.assertIsInstance(pdu, pdutype)
+                if i == 3:  # Skip first Ack
+                    break
+                print("\nSRC ", pdu, "\n")
+                with self.assertRaises(PduIgnoredForSource):
+                    self.src.state_machine(pdu)
+
+        self.src.state_machine()
+        self.dst.state_machine()
+
+        self.assertEqual(self.src.step, source.TransactionStep.IDLE)
+        self.assertEqual(self.dst.step, dest.TransactionStep.IDLE)
+
+
+#
+#
+#
+#    def run(self):
+#        while packet := self.downlink.get():
+#            with self.lock:
+#                self.src.state_machine(packet)
+#                self.src.state_machine()
+#                while self.src.packets_ready:
+#                    pdu = self.src.get_next_packet().pdu
+#                    self.uplink.put(pdu)
+#

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -350,7 +350,7 @@ class TestCfdp(unittest.TestCase):
     def test_proxy_put_request(self):
         """
         The ground asks the spacecraft to send a file to someone (the ground in our case), the
-        spacecraft creates a new transation to send it, then starts a transaction to send a
+        spacecraft creates a new transaction to send it, then starts a transaction to send a
         "we've finished" message.
         """
         # gnd_src --> s/c_dst Metadata      T1
@@ -366,7 +366,6 @@ class TestCfdp(unittest.TestCase):
         # gnd_dst --> s/c_src Finished      T2
         # gnd_dst <-- s/c_src Ack (Fin)     T2
 
-        # Not entirely clear on how this is supposed to work.
         # gnd_src <-- s/c_dst Metadata      T3
         # gnd_src <-- s/c_dst Eof           T3
         # gnd_src --> s/c_dst Ack (EoF)     T3

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import unittest
+from abc import ABCMeta
 from datetime import timedelta
 from pathlib import Path
 from queue import Empty, SimpleQueue
@@ -377,7 +378,7 @@ class TestCfdp(unittest.TestCase):
             ProxyPutRequestParams(
                 dest_entity_id=self.gnd_id,
                 source_file_name=CfdpLv.from_str(self.file.name),
-                dest_file_name=CfdpLv.from_str(self.file.name)
+                dest_file_name=CfdpLv.from_str(self.file.name + "2")
             )
         ).to_generic_msg_to_user_tlv()
         # Yamcs will always send a proxy transmission mode message, for both class 1 or class 2.
@@ -394,146 +395,37 @@ class TestCfdp(unittest.TestCase):
         )
 
         self._put_req_queue_gnd.put(put)
+        time.sleep(0.2)
 
         # gnd_src --> s/c_dst Metadata      T1
-        time.sleep(0.2)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, MetadataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, MetadataPdu)
         # gnd_src --> s/c_dst Eof           T1
-        time.sleep(0.15)
-        print("\n\n\na\n\n\n")
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(get_packet_destination(pdu.pdu))
-        self.assertIsInstance(pdu.pdu, EofPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, EofPdu)
         # gnd_src <-- s/c_dst Ack (EoF)     T1
-        time.sleep(0.15)
-        print("\n\n\nb\n\n\n")
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
+        self.dest_sc_to_gnd_src(0.15, AckPdu)
         # gnd_src <-- s/c_dst Finished      T1
-        time.sleep(0.15)
-        print("\n\n\nc\n\n\n")
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FinishedPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
+        self.dest_sc_to_gnd_src(0.15, FinishedPdu)
         # gnd_src --> s/c_dst Ack (Fin)     T1
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue.empty())
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-        time.sleep(1)
+        self.src_gnd_to_sc_dest(0.4, AckPdu)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         # End of transaction 1. The queues used for it should be empty, as the next transactions
         # use the opposite queues.
-        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        print("\n\n\nDONE WITH TRANSACTION 1\n\n\n")
 
-        # gnd_src --> s/c_dst Metadata      T2
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, MetadataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # gnd_src --> s/c_dst Metadata      T2
-        time.sleep(0.2)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FileDataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # gnd_src --> s/c_dst Eof           T2
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(get_packet_destination(pdu.pdu))
-        self.assertIsInstance(pdu.pdu, EofPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # gnd_src <-- s/c_dst Ack (EoF)     T2
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
-        # gnd_src <-- s/c_dst Finished      T2
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FinishedPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
-        # gnd_src --> s/c_dst Ack (Fin)     T2
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue.empty())
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-        time.sleep(1)
-        # End of transaction 2.
-        print("\n\n\nDONE WITH TRANSACTION 2\n\n\n")
+        # gnd_dst <-- s/c_src Metadata      T2
+        self.src_sc_to_gnd_dest(0.15, MetadataPdu)
+        # gnd_dst <-- s/c_src Filedata      T2
+        self.src_sc_to_gnd_dest(0.15, FileDataPdu)
+        # gnd_dst <-- s/c_src Eof           T2
+        self.src_sc_to_gnd_dest(0.15, EofPdu)
+        # gnd_dst --> s/c_src Ack (EoF)     T2
+        self.dest_gnd_to_sc_src(0.15, AckPdu)
+        # gnd_dst --> s/c_src Finished      T2
+        self.dest_gnd_to_sc_src(0.15, FinishedPdu)
+        # gnd_dst <-- s/c_src Ack (Fin)     T2
+        self.src_sc_to_gnd_dest(0.15, AckPdu)
 
 
-        # gnd_src --> s/c_dst Metadata      T3
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, MetadataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # gnd_src --> s/c_dst Metadata      T3
-        time.sleep(0.2)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FileDataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # gnd_src --> s/c_dst Eof           T3
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(get_packet_destination(pdu.pdu))
-        self.assertIsInstance(pdu.pdu, EofPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # gnd_src <-- s/c_dst Ack (EoF)     T3
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
-        # gnd_src <-- s/c_dst Finished      T3
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FinishedPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
-        # gnd_src --> s/c_dst Ack (Fin)     T3
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue.empty())
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-        time.sleep(1)
-        # End of transaction 3.
 
 
         # Make sure we've returned to idle / empty.
@@ -550,3 +442,30 @@ class TestCfdp(unittest.TestCase):
             source.TransactionStep.IDLE
         )
 
+    def src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get())
+        self.assertIsInstance(pdu, expected_type)
+        self._cfdp_dest_queue.put(pdu)
+        if delay > 0:
+            time.sleep(delay)
+
+    def dest_gnd_to_sc_src(self, delay: float, expected_type: ABCMeta) -> None:
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get())
+        self.assertIsInstance(pdu, expected_type)
+        self._cfdp_src_queue.put(pdu)
+        if delay > 0:
+            time.sleep(delay)
+
+    def src_sc_to_gnd_dest(self, delay: float, expected_type: ABCMeta) -> None:
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue.get())
+        self.assertIsInstance(pdu, expected_type)
+        self._cfdp_dest_queue_gnd.put(pdu)
+        if delay > 0:
+            time.sleep(delay)
+
+    def dest_sc_to_gnd_src(self, delay: float, expected_type: ABCMeta) -> None:
+        pdu = PduFactory.from_raw(self._cfdp_tm_queue.get())
+        self.assertIsInstance(pdu, expected_type)
+        self._cfdp_src_queue_gnd.put(pdu)
+        if delay > 0:
+            time.sleep(delay)

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -4,47 +4,27 @@ import unittest
 from abc import ABCMeta
 from datetime import timedelta
 from pathlib import Path
-from queue import Empty, SimpleQueue
+from queue import SimpleQueue
 from tempfile import NamedTemporaryFile
-from typing import Any
 
-from cfdppy import get_packet_destination
-from cfdppy.exceptions import PduIgnoredForSource
 from cfdppy.handler import dest, source
-from cfdppy.handler.dest import DestHandler
-from cfdppy.handler.source import SourceHandler
 from cfdppy.mib import (
     CheckTimerProvider,
-    DefaultFaultHandlerBase,
-    IndicationConfig,
-    LocalEntityConfig,
     RemoteEntityConfig,
     RemoteEntityConfigTable,
 )
 from cfdppy.request import PutRequest
-from cfdppy.user import (
-    CfdpUserBase,
-    FileSegmentRecvdParams,
-    MetadataRecvParams,
-    TransactionFinishedParams,
-    TransactionParams,
-)
 from spacepackets.cfdp import CfdpLv
-from spacepackets.cfdp.defs import ChecksumType, ConditionCode, TransactionId, TransmissionMode
+from spacepackets.cfdp.defs import ChecksumType, TransmissionMode
 from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu, PduFactory
 from spacepackets.cfdp.tlv import (
-    DirectoryListingResponse,
-    DirectoryOperationMessageType,
-    OriginatingTransactionId,
-    ProxyMessageType,
+    DirectoryListingRequest,
+    DirectoryParams,
     ProxyPutRequest,
     ProxyPutRequestParams,
-    ProxyPutResponse,
-    ProxyPutResponseParams,
     ProxyTransmissionMode,
 )
 from spacepackets.countdown import Countdown
-from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
 
 from oresat_c3.protocols.cfdp import DestEntityHandler, SourceEntityHandler
@@ -72,7 +52,6 @@ def put_request(destination: ByteFieldU8, file_path: str) -> PutRequest:
     )
 
 
-# @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
 class TestCfdp(unittest.TestCase):
     def setUp(self):
         self.file = NamedTemporaryFile()
@@ -94,9 +73,7 @@ class TestCfdp(unittest.TestCase):
                 RemoteEntityConfig(
                     entity_id=self.gnd_id,
                     max_file_segment_len=None,
-                    # FIXME this value should come from EdlPacket but EdlPacket does not define it.
-                    # How does the exact value get determined? Currently it's just a mirror of the
-                    # value in edl_file_upload.py
+                    # FIXME this value should come from EdlPacket.
                     max_packet_len=950,
                     closure_requested=True,
                     crc_on_transmission=False,
@@ -124,8 +101,6 @@ class TestCfdp(unittest.TestCase):
         )
 
         # Ground station handling
-
-
         self._put_req_queue_gnd = SimpleQueue()
         self._cfdp_src_queue_gnd = SimpleQueue()
         self._cfdp_dest_queue_gnd = SimpleQueue()
@@ -136,9 +111,6 @@ class TestCfdp(unittest.TestCase):
                 RemoteEntityConfig(
                     entity_id=self.sat_id,
                     max_file_segment_len=None,
-                    # FIXME this value should come from EdlPacket but EdlPacket does not define it.
-                    # How does the exact value get determined? Currently it's just a mirror of the
-                    # value in edl_file_upload.py
                     max_packet_len=950,
                     closure_requested=True,
                     crc_on_transmission=False,
@@ -193,17 +165,17 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.2)
 
         # src --> Metadata
-        self.src_gnd_to_sc_dest(0.15, MetadataPdu)
+        self._src_gnd_to_sc_dest(0.15, MetadataPdu)
         # src --> Filedata
-        self.src_gnd_to_sc_dest(0.15, FileDataPdu)
+        self._src_gnd_to_sc_dest(0.15, FileDataPdu)
         # src --> EoF
-        self.src_gnd_to_sc_dest(0.15, EofPdu)
+        self._src_gnd_to_sc_dest(0.15, EofPdu)
         # dst <-- Ack (EoF)
-        self.src_gnd_to_sc_dest(0.15, AckPdu)
+        self._src_gnd_to_sc_dest(0.15, AckPdu)
         # dst <-- Finished
-        self.src_gnd_to_sc_dest(0.15, FinishedPdu)
+        self._src_gnd_to_sc_dest(0.15, FinishedPdu)
         # src --> Ack (Finished)
-        self.src_gnd_to_sc_dest(0.15, AckPdu)
+        self._src_gnd_to_sc_dest(0.15, AckPdu)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)
@@ -240,18 +212,18 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.2)
 
         # src --> Metadata
-        self.src_gnd_to_sc_dest(0.15, MetadataPdu)
+        self._src_gnd_to_sc_dest(0.15, MetadataPdu)
         # src --> Filedata
-        self.src_gnd_to_sc_dest(0.15, FileDataPdu)
+        self._src_gnd_to_sc_dest(0.15, FileDataPdu)
         # src --> EoF
-        self.src_gnd_to_sc_dest(0.15, EofPdu)
+        self._src_gnd_to_sc_dest(0.15, EofPdu)
         # dst X-- Ack (EoF)
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         pdu_packed = self._cfdp_tm_queue.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
         # dst <-- Finished
-        self.dest_sc_to_gnd_src(0.15, FinishedPdu)
+        self._dest_sc_to_gnd_src(0.15, FinishedPdu)
 
         print(self.cfdp_source_handler_gnd.source_handler.step)
 
@@ -289,7 +261,7 @@ class TestCfdp(unittest.TestCase):
             source.TransactionStep.IDLE
         )
 
-    def test_proxy_put_request(self):
+    def test_proxy_put_operation(self):
         """
         The ground asks the spacecraft to send a file to someone (the ground in our case), the
         spacecraft creates a new transaction to send it, then starts a transaction to send a
@@ -339,41 +311,41 @@ class TestCfdp(unittest.TestCase):
         time.sleep(0.2)
 
         # gnd_src --> s/c_dst Metadata      T1
-        self.src_gnd_to_sc_dest(0.15, MetadataPdu)
+        self._src_gnd_to_sc_dest(0.15, MetadataPdu)
         # gnd_src --> s/c_dst Eof           T1
-        self.src_gnd_to_sc_dest(0.15, EofPdu)
+        self._src_gnd_to_sc_dest(0.15, EofPdu)
         # gnd_src <-- s/c_dst Ack (EoF)     T1
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        self.dest_sc_to_gnd_src(0.15, AckPdu)
+        self._dest_sc_to_gnd_src(0.15, AckPdu)
         # gnd_src <-- s/c_dst Finished      T1
-        self.dest_sc_to_gnd_src(0.15, FinishedPdu)
+        self._dest_sc_to_gnd_src(0.15, FinishedPdu)
         # gnd_src --> s/c_dst Ack (Fin)     T1
-        self.src_gnd_to_sc_dest(0.15, AckPdu)
+        self._src_gnd_to_sc_dest(0.15, AckPdu)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
 
         # gnd_dst <-- s/c_src Metadata      T2
-        self.src_sc_to_gnd_dest(0.15, MetadataPdu)
+        self._src_sc_to_gnd_dest(0.15, MetadataPdu)
         # gnd_dst <-- s/c_src Filedata      T2
-        self.src_sc_to_gnd_dest(0.15, FileDataPdu)
+        self._src_sc_to_gnd_dest(0.15, FileDataPdu)
         # gnd_dst <-- s/c_src Eof           T2
-        self.src_sc_to_gnd_dest(0.15, EofPdu)
+        self._src_sc_to_gnd_dest(0.15, EofPdu)
         # gnd_dst --> s/c_src Ack (EoF)     T2
-        self.dest_gnd_to_sc_src(0.15, AckPdu)
+        self._dest_gnd_to_sc_src(0.15, AckPdu)
         # gnd_dst --> s/c_src Finished      T2
-        self.dest_gnd_to_sc_src(0.15, FinishedPdu)
+        self._dest_gnd_to_sc_src(0.15, FinishedPdu)
         # gnd_dst <-- s/c_src Ack (Fin)     T2
-        self.src_sc_to_gnd_dest(0.15, AckPdu)
+        self._src_sc_to_gnd_dest(0.15, AckPdu)
 
         # gnd_dst <-- s/c_src Metadata      T3
-        self.src_sc_to_gnd_dest(0.15, MetadataPdu)
+        self._src_sc_to_gnd_dest(0.15, MetadataPdu)
         # gnd_dst <-- s/c_src Eof           T3
-        self.src_sc_to_gnd_dest(0.15, EofPdu)
+        self._src_sc_to_gnd_dest(0.15, EofPdu)
         # gnd_dst --> s/c_src Ack (EoF)     T3
-        self.dest_gnd_to_sc_src(0.15, AckPdu)
+        self._dest_gnd_to_sc_src(0.15, AckPdu)
         # gnd_dst --> s/c_src Finished      T3
-        self.dest_gnd_to_sc_src(0.15, FinishedPdu)
+        self._dest_gnd_to_sc_src(0.15, FinishedPdu)
         # gnd_dst <-- s/c_src Ack (Fin)     T3
-        self.src_sc_to_gnd_dest(0.15, AckPdu)
+        self._src_sc_to_gnd_dest(0.15, AckPdu)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)
@@ -389,28 +361,108 @@ class TestCfdp(unittest.TestCase):
             source.TransactionStep.IDLE
         )
 
-    def src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:
+    def test_directory_listing(self):
+        """
+        The ground asks the spacecraft for the vfs root directory listing to be sent back
+        as a file. The spacecraft sends the directory listing as a file.
+
+        This will attempt to mimic the YAMCS request since it breaks the upstream spacepackets.py
+        package.
+        """
+        # gnd_src --> s/c_dst Metadata      T1
+        # gnd_src --> s/c_dst Eof           T1
+        # gnd_src <-- s/c_dst Ack (EoF)     T1
+        # gnd_src <-- s/c_dst Finished      T1
+        # gnd_src --> s/c_dst Ack (Fin)     T1
+
+        # gnd_dst <-- s/c_src Metadata      T2
+        # gnd_dst <-- s/c_src Filedata      T2
+        # gnd_dst <-- s/c_src Eof           T2
+        # gnd_dst --> s/c_src Ack (EoF)     T2
+        # gnd_dst --> s/c_src Finished      T2
+        # gnd_dst <-- s/c_src Ack (Fin)     T2
+        dir_req = DirectoryListingRequest(
+            DirectoryParams(
+                dir_path=CfdpLv.from_str(""),
+                dir_file_name=CfdpLv.from_str(".dirlist.notsaved")
+            )
+        ).to_generic_msg_to_user_tlv()
+        put = PutRequest(
+            destination_id=self.sat_id,
+            source_file=None,
+            dest_file=None,
+            trans_mode=None,
+            closure_requested=True,
+            msgs_to_user=[dir_req],
+        )
+        self._put_req_queue_gnd.put(put)
+        time.sleep(0.2)
+
+        # gnd_src --> s/c_dst Metadata      T1
+        self._src_gnd_to_sc_dest(0.15, MetadataPdu)
+        # gnd_src --> s/c_dst Eof           T1
+        self._src_gnd_to_sc_dest(0.15, EofPdu)
+        # gnd_src <-- s/c_dst Ack (EoF)     T1
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self._dest_sc_to_gnd_src(0.15, AckPdu)
+        # gnd_src <-- s/c_dst Finished      T1
+        self._dest_sc_to_gnd_src(0.15, FinishedPdu)
+        # gnd_src --> s/c_dst Ack (Fin)     T1
+        self._src_gnd_to_sc_dest(0.15, AckPdu)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+
+        time.sleep(100)
+
+        # gnd_dst <-- s/c_src Metadata      T2
+        self._src_sc_to_gnd_dest(0.15, MetadataPdu)
+        # gnd_dst <-- s/c_src Filedata      T2
+        self._src_sc_to_gnd_dest(0.15, FileDataPdu)
+        # gnd_dst <-- s/c_src Eof           T2
+        self._src_sc_to_gnd_dest(0.15, EofPdu)
+        # gnd_dst --> s/c_src Ack (EoF)     T2
+        self._dest_gnd_to_sc_src(0.15, AckPdu)
+        # gnd_dst --> s/c_src Finished      T2
+        self._dest_gnd_to_sc_src(0.15, FinishedPdu)
+        # gnd_dst <-- s/c_src Ack (Fin)     T2
+        self._src_sc_to_gnd_dest(0.15, AckPdu)
+
+        # Make sure we've returned to idle / empty.
+        time.sleep(1)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler_gnd.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+
+
+    def _src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:
         pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_dest_queue.put(pdu)
         if delay > 0:
             time.sleep(delay)
 
-    def dest_gnd_to_sc_src(self, delay: float, expected_type: ABCMeta) -> None:
+    def _dest_gnd_to_sc_src(self, delay: float, expected_type: ABCMeta) -> None:
         pdu = PduFactory.from_raw(self._cfdp_tm_queue_gnd.get())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_src_queue.put(pdu)
         if delay > 0:
             time.sleep(delay)
 
-    def src_sc_to_gnd_dest(self, delay: float, expected_type: ABCMeta) -> None:
+    def _src_sc_to_gnd_dest(self, delay: float, expected_type: ABCMeta) -> None:
         pdu = PduFactory.from_raw(self._cfdp_tm_queue.get())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_dest_queue_gnd.put(pdu)
         if delay > 0:
             time.sleep(delay)
 
-    def dest_sc_to_gnd_src(self, delay: float, expected_type: ABCMeta) -> None:
+    def _dest_sc_to_gnd_src(self, delay: float, expected_type: ABCMeta) -> None:
         pdu = PduFactory.from_raw(self._cfdp_tm_queue.get())
         self.assertIsInstance(pdu, expected_type)
         self._cfdp_src_queue_gnd.put(pdu)

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -189,53 +189,21 @@ class TestCfdp(unittest.TestCase):
         # src --> dst Ack (Finished)
 
         put = put_request(self.sat_id, self.file.name)
-
         self._put_req_queue_gnd.put(put)
+        time.sleep(0.2)
 
         # src --> Metadata
-        time.sleep(0.2)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, MetadataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, MetadataPdu)
         # src --> Filedata
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FileDataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, FileDataPdu)
         # src --> EoF
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(get_packet_destination(pdu.pdu))
-        self.assertIsInstance(pdu.pdu, EofPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, EofPdu)
         # dst <-- Ack (EoF)
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, AckPdu)
         # dst <-- Finished
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FinishedPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, FinishedPdu)
         # src --> Ack (Finished)
-        time.sleep(0.15)
-        self.assertTrue(self._cfdp_tm_queue.empty())
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, AckPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
+        self.src_gnd_to_sc_dest(0.15, AckPdu)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)
@@ -268,51 +236,24 @@ class TestCfdp(unittest.TestCase):
         # src --> Ack (Finished)
 
         put = put_request(self.sat_id, self.file.name)
-
         self._put_req_queue_gnd.put(put)
+        time.sleep(0.2)
 
         # src --> Metadata
-        time.sleep(0.2)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
-        self.assertIsInstance(pdu.pdu, MetadataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, MetadataPdu)
         # src --> Filedata
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
-        self.assertIsInstance(pdu.pdu, FileDataPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
+        self.src_gnd_to_sc_dest(0.15, FileDataPdu)
         # src --> EoF
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue_gnd.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
-        self.assertIsInstance(pdu.pdu, EofPdu)
-        self._cfdp_dest_queue.put(pdu.pdu)
-
-        # dst <-- Ack (EoF)
+        self.src_gnd_to_sc_dest(0.15, EofPdu)
+        # dst X-- Ack (EoF)
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         pdu_packed = self._cfdp_tm_queue.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        print(f"\n\n{get_packet_destination(pdu.pdu)}\n\n")
-
         # dst <-- Finished
-        time.sleep(0.15)
-        pdu_packed = self._cfdp_tm_queue.get()
-        pdu = PduFactory.from_raw_to_holder(pdu_packed)
-        self.assertIsInstance(pdu.pdu, FinishedPdu)
-        self._cfdp_src_queue_gnd.put(pdu.pdu)
-        time.sleep(1)
+        self.dest_sc_to_gnd_src(0.15, FinishedPdu)
 
         print(self.cfdp_source_handler_gnd.source_handler.step)
-
-        time.sleep(10)
 
         # dst <-- Finished
         time.sleep(0.15)
@@ -407,10 +348,8 @@ class TestCfdp(unittest.TestCase):
         # gnd_src <-- s/c_dst Finished      T1
         self.dest_sc_to_gnd_src(0.15, FinishedPdu)
         # gnd_src --> s/c_dst Ack (Fin)     T1
-        self.src_gnd_to_sc_dest(0.4, AckPdu)
+        self.src_gnd_to_sc_dest(0.15, AckPdu)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        # End of transaction 1. The queues used for it should be empty, as the next transactions
-        # use the opposite queues.
 
         # gnd_dst <-- s/c_src Metadata      T2
         self.src_sc_to_gnd_dest(0.15, MetadataPdu)
@@ -425,8 +364,16 @@ class TestCfdp(unittest.TestCase):
         # gnd_dst <-- s/c_src Ack (Fin)     T2
         self.src_sc_to_gnd_dest(0.15, AckPdu)
 
-
-
+        # gnd_dst <-- s/c_src Metadata      T3
+        self.src_sc_to_gnd_dest(0.15, MetadataPdu)
+        # gnd_dst <-- s/c_src Eof           T3
+        self.src_sc_to_gnd_dest(0.15, EofPdu)
+        # gnd_dst --> s/c_src Ack (EoF)     T3
+        self.dest_gnd_to_sc_src(0.15, AckPdu)
+        # gnd_dst --> s/c_src Finished      T3
+        self.dest_gnd_to_sc_src(0.15, FinishedPdu)
+        # gnd_dst <-- s/c_src Ack (Fin)     T3
+        self.src_sc_to_gnd_dest(0.15, AckPdu)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -5,7 +5,7 @@ from abc import ABCMeta
 from datetime import timedelta
 from pathlib import Path
 from queue import SimpleQueue
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 
 from cfdppy.handler import dest, source
 from cfdppy.mib import (
@@ -14,9 +14,18 @@ from cfdppy.mib import (
     RemoteEntityConfigTable,
 )
 from cfdppy.request import PutRequest
+from cfdppy.restricted_filestore import RestrictedFilestore
 from spacepackets.cfdp import CfdpLv
 from spacepackets.cfdp.defs import ChecksumType, TransmissionMode
-from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, MetadataPdu, PduFactory
+from spacepackets.cfdp.pdu import (
+    AckPdu,
+    EofPdu,
+    FileDataPdu,
+    FinishedPdu,
+    MetadataPdu,
+    NakPdu,
+    PduFactory,
+)
 from spacepackets.cfdp.tlv import (
     DirectoryListingRequest,
     DirectoryParams,
@@ -27,6 +36,7 @@ from spacepackets.cfdp.tlv import (
 from spacepackets.countdown import Countdown
 from spacepackets.util import ByteFieldU8
 
+from oresat_c3.protocols.cachestore import CacheStore
 from oresat_c3.protocols.cfdp import DestEntityHandler, SourceEntityHandler
 
 
@@ -54,9 +64,17 @@ def put_request(destination: ByteFieldU8, file_path: str) -> PutRequest:
 
 class TestCfdp(unittest.TestCase):
     def setUp(self):
-        self.file = NamedTemporaryFile()
-        self.file.write(b"This is some example data\x01\x02\x03")
-        self.file.flush()
+        self.sat_file = Path("c3_tmp_123")
+        self.cachedir = TemporaryDirectory()
+        self.cache = CacheStore(self.cachedir.name)
+        self.cache.create_file(self.sat_file)
+        self.cache.write_data(self.sat_file, b"This is some example data\x01\x02\x03")
+
+        self.cachedir_gnd = TemporaryDirectory()
+        self.cache_gnd = RestrictedFilestore(Path(self.cachedir_gnd.name))
+        self.gnd_file = Path("c3_tmp_1234")
+        self.cache_gnd.create_file(self.gnd_file)
+        self.cache_gnd.write_data(self.gnd_file, b"This is some example data\x01\x02\x03", None)
 
         self.gnd_id = ByteFieldU8(0)
         self.sat_id = ByteFieldU8(1)
@@ -86,6 +104,7 @@ class TestCfdp(unittest.TestCase):
             self._put_req_queue,
             self._cfdp_src_queue,
             self._cfdp_tm_queue,
+            self.cache,
             remote_entities,
             self.gnd_id,
             self.sat_id,
@@ -95,6 +114,7 @@ class TestCfdp(unittest.TestCase):
             self._put_req_queue,
             self._cfdp_dest_queue,
             self._cfdp_tm_queue,
+            self.cache,
             remote_entities,
             self.sat_id,
             self.stop_signal
@@ -123,6 +143,7 @@ class TestCfdp(unittest.TestCase):
             self._put_req_queue_gnd,
             self._cfdp_src_queue_gnd,
             self._cfdp_tm_queue_gnd,
+            self.cache_gnd,
             remote_entities_gnd,
             self.sat_id,
             self.gnd_id,
@@ -132,6 +153,7 @@ class TestCfdp(unittest.TestCase):
             self._put_req_queue_gnd,
             self._cfdp_dest_queue_gnd,
             self._cfdp_tm_queue_gnd,
+            self.cache_gnd,
             remote_entities_gnd,
             self.gnd_id,
             self.stop_signal
@@ -143,6 +165,8 @@ class TestCfdp(unittest.TestCase):
         self.cfdp_dest_handler_gnd.start()
 
     def tearDown(self):
+        self.cachedir.cleanup()
+        self.cachedir_gnd.cleanup()
         self.stop_signal.set()
         self.cfdp_source_handler.join()
         self.cfdp_dest_handler.join()
@@ -160,7 +184,7 @@ class TestCfdp(unittest.TestCase):
         # src <-- dst Finished
         # src --> dst Ack (Finished)
 
-        put = put_request(self.sat_id, self.file.name)
+        put = put_request(self.sat_id, self.gnd_file.name)
         self._put_req_queue_gnd.put(put)
         time.sleep(0.2)
 
@@ -171,9 +195,9 @@ class TestCfdp(unittest.TestCase):
         # src --> EoF
         self._src_gnd_to_sc_dest(0.15, EofPdu)
         # dst <-- Ack (EoF)
-        self._src_gnd_to_sc_dest(0.15, AckPdu)
+        self._dest_sc_to_gnd_src(0.15, AckPdu)
         # dst <-- Finished
-        self._src_gnd_to_sc_dest(0.15, FinishedPdu)
+        self._dest_sc_to_gnd_src(0.15, FinishedPdu)
         # src --> Ack (Finished)
         self._src_gnd_to_sc_dest(0.15, AckPdu)
 
@@ -190,6 +214,11 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler_gnd.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertEqual(
+            self.cache.read_data(self.gnd_file),
+            self.cache_gnd.read_data(self.gnd_file)
+        )
+        self.cache.delete_file(self.gnd_file)
 
     # Broken for now. For some reason CFDP stops resending EOFs after recieving a finished PDU,
     # leaving it stuck waiting for an ACK (EOF) without resending EOFs.
@@ -260,6 +289,11 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler_gnd.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertEqual(
+            self.cache.read_data(self.gnd_file),
+            self.cache_gnd.read_data(self.gnd_file)
+        )
+        self.cache.delete_file(self.gnd_file)
 
     def test_proxy_put_operation(self):
         """
@@ -285,13 +319,11 @@ class TestCfdp(unittest.TestCase):
         # gnd_src --> s/c_dst Ack (EoF)     T3
         # gnd_src --> s/c_dst Finished      T3
         # gnd_src <-- s/c_dst Ack (Fin)     T3
-
-
         proxy_put = ProxyPutRequest(
             ProxyPutRequestParams(
                 dest_entity_id=self.gnd_id,
-                source_file_name=CfdpLv.from_str(self.file.name),
-                dest_file_name=CfdpLv.from_str(self.file.name + "2")
+                source_file_name=CfdpLv.from_str(self.sat_file.name),
+                dest_file_name=CfdpLv.from_str(self.sat_file.name)
             )
         ).to_generic_msg_to_user_tlv()
         # Yamcs will always send a proxy transmission mode message, for both class 1 or class 2.
@@ -360,11 +392,17 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler_gnd.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertEqual(
+            self.cache.read_data(self.sat_file),
+            self.cache_gnd.read_data(self.sat_file)
+        )
+        self.cache_gnd.delete_file(self.sat_file)
 
     def test_directory_listing(self):
         """
         The ground asks the spacecraft for the vfs root directory listing to be sent back
-        as a file. The spacecraft sends the directory listing as a file.
+        as a file. The spacecraft sends the directory listing as a file. The ground requests
+        that the spacecraft send a proxy put response (T3).
 
         This will attempt to mimic the YAMCS request since it breaks the upstream spacepackets.py
         package.
@@ -381,10 +419,20 @@ class TestCfdp(unittest.TestCase):
         # gnd_dst --> s/c_src Ack (EoF)     T2
         # gnd_dst --> s/c_src Finished      T2
         # gnd_dst <-- s/c_src Ack (Fin)     T2
+
+        # gnd_src <-- s/c_dst Metadata      T3
+        # gnd_src <-- s/c_dst Eof           T3
+        # gnd_src --> s/c_dst Ack (EoF)     T3
+        # gnd_src --> s/c_dst Finished      T3
+        # gnd_src <-- s/c_dst Ack (Fin)     T3
+
+        # this is put into the working directory. This is awful and should be fixed, but that would
+        # require breaking cachestore even more.
+        dir_listing_gnd = ".dirlist.notsaved"
         dir_req = DirectoryListingRequest(
             DirectoryParams(
                 dir_path=CfdpLv.from_str(""),
-                dir_file_name=CfdpLv.from_str(".dirlist.notsaved")
+                dir_file_name=CfdpLv.from_str(dir_listing_gnd)
             )
         ).to_generic_msg_to_user_tlv()
         put = PutRequest(
@@ -411,8 +459,6 @@ class TestCfdp(unittest.TestCase):
         self._src_gnd_to_sc_dest(0.15, AckPdu)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
 
-        time.sleep(100)
-
         # gnd_dst <-- s/c_src Metadata      T2
         self._src_sc_to_gnd_dest(0.15, MetadataPdu)
         # gnd_dst <-- s/c_src Filedata      T2
@@ -424,6 +470,17 @@ class TestCfdp(unittest.TestCase):
         # gnd_dst --> s/c_src Finished      T2
         self._dest_gnd_to_sc_src(0.15, FinishedPdu)
         # gnd_dst <-- s/c_src Ack (Fin)     T2
+        self._src_sc_to_gnd_dest(0.15, AckPdu)
+
+        # gnd_dst <-- s/c_src Metadata      T3
+        self._src_sc_to_gnd_dest(0.15, MetadataPdu)
+        # gnd_dst <-- s/c_src Eof           T3
+        self._src_sc_to_gnd_dest(0.15, EofPdu)
+        # gnd_dst --> s/c_src Ack (EoF)     T3
+        self._dest_gnd_to_sc_src(0.15, AckPdu)
+        # gnd_dst --> s/c_src Finished      T3
+        self._dest_gnd_to_sc_src(0.15, FinishedPdu)
+        # gnd_dst <-- s/c_src Ack (Fin)     T3
         self._src_sc_to_gnd_dest(0.15, AckPdu)
 
         # Make sure we've returned to idle / empty.
@@ -439,6 +496,12 @@ class TestCfdp(unittest.TestCase):
             self.cfdp_source_handler_gnd.source_handler.step,
             source.TransactionStep.IDLE
         )
+        self.assertEqual(
+            self.cache.read_data(Path(dir_listing_gnd)),
+            self.cache_gnd.read_data(Path(dir_listing_gnd), None)
+        )
+        self.cache.delete_file(Path(dir_listing_gnd))
+        self.cache_gnd.delete_file(Path(dir_listing_gnd))
 
 
     def _src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import timedelta
 from pathlib import Path
+from queue import Empty, SimpleQueue
 from tempfile import NamedTemporaryFile
 from typing import Any
 
@@ -29,6 +30,8 @@ from spacepackets.cfdp.pdu import AckPdu, EofPdu, FileDataPdu, FinishedPdu, Meta
 from spacepackets.countdown import Countdown
 from spacepackets.seqcount import SeqCountProvider
 from spacepackets.util import ByteFieldU8
+
+from oresat_c3.protocols.cfdp import DestEntityHandler, SourceEntityHandler
 
 
 class CountdownProvider(CheckTimerProvider):
@@ -132,62 +135,85 @@ class TestCfdp(unittest.TestCase):
         self.file.write(b"This is some example data\x01\x02\x03")
         self.file.flush()
 
-        self.src_id = ByteFieldU8(0)
-        self.dst_id = ByteFieldU8(1)
+        self.gnd_id = ByteFieldU8(0)
+        self.sat_id = ByteFieldU8(1)
 
-        src_cfg = LocalEntityConfig(
-            local_entity_id=self.src_id,
-            indication_cfg=IndicationConfig(),
-            default_fault_handlers=PrintFaults(),
-        )
+        self._put_req_queue = SimpleQueue()
+        self._cfdp_src_queue = SimpleQueue()
+        self._cfdp_dest_queue = SimpleQueue()
+        self._cfdp_tm_queue = SimpleQueue()
 
-        dst_cfg = LocalEntityConfig(
-            local_entity_id=self.dst_id,
-            indication_cfg=IndicationConfig(),
-            default_fault_handlers=PrintFaults(),
-        )
-
-        src_remote_entities = RemoteEntityConfigTable(
+        # Satellite handling
+        remote_entities = RemoteEntityConfigTable(
             [
                 RemoteEntityConfig(
-                    entity_id=self.dst_id,
+                    entity_id=self.gnd_id,
                     max_file_segment_len=None,
+                    # FIXME this value should come from EdlPacket but EdlPacket does not define it.
+                    # How does the exact value get determined? Currently it's just a mirror of the
+                    # value in edl_file_upload.py
                     max_packet_len=950,
                     closure_requested=False,
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
-                    crc_type=ChecksumType.CRC_32,
+                    crc_type=ChecksumType.MODULAR,
                 ),
             ]
         )
+        self.cfdp_source_handler = SourceEntityHandler(
+            self._put_req_queue,
+            self._cfdp_src_queue,
+            self._cfdp_tm_queue,
+            remote_entities,
+            self.gnd_id,
+            self.sat_id
+        )
+        self.cfdp_dest_handler = DestEntityHandler(
+            self._put_req_queue,
+            self._cfdp_dest_queue,
+            self._cfdp_tm_queue,
+            remote_entities,
+            self.sat_id
+        )
 
-        dst_remote_entities = RemoteEntityConfigTable(
+        # Ground station handling
+
+
+        self._put_req_queue_gnd = SimpleQueue()
+        self._cfdp_src_queue_gnd = SimpleQueue()
+        self._cfdp_dest_queue_gnd = SimpleQueue()
+        self._cfdp_tm_queue_gnd = SimpleQueue()
+
+        remote_entities_gnd = RemoteEntityConfigTable(
             [
                 RemoteEntityConfig(
-                    entity_id=self.src_id,
+                    entity_id=self.sat_id,
                     max_file_segment_len=None,
+                    # FIXME this value should come from EdlPacket but EdlPacket does not define it.
+                    # How does the exact value get determined? Currently it's just a mirror of the
+                    # value in edl_file_upload.py
                     max_packet_len=950,
                     closure_requested=False,
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
-                    crc_type=ChecksumType.CRC_32,
+                    crc_type=ChecksumType.MODULAR,
                 ),
             ]
         )
-
-        self.src = SourceHandler(
-            cfg=src_cfg,
-            user=PrintUser(),
-            remote_cfg_table=src_remote_entities,
-            check_timer_provider=CountdownProvider(),
-            seq_num_provider=SeqCountProvider(16),
+        self.cfdp_source_handler_gnd = SourceEntityHandler(
+            self._put_req_queue_gnd,
+            self._cfdp_src_queue_gnd,
+            self._cfdp_tm_queue_gnd,
+            remote_entities_gnd,
+            self.sat_id,
+            self.gnd_id
         )
-
-        self.dst = DestHandler(
-            cfg=dst_cfg,
-            user=PrintUser(),
-            remote_cfg_table=dst_remote_entities,
-            check_timer_provider=CountdownProvider(),
+        self.cfdp_dest_handler_gnd = DestEntityHandler(
+            self._put_req_queue_gnd,
+            self._cfdp_dest_queue_gnd,
+            self._cfdp_tm_queue_gnd,
+            remote_entities_gnd,
+            self.gnd_id
         )
 
     def tearDown(self):
@@ -204,73 +230,52 @@ class TestCfdp(unittest.TestCase):
         # src --> Ack (Finished)
         pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
 
-        put = put_request(self.dst_id, self.file.name)
-        self.assertTrue(self.src.put_request(put))
+        self.cfdp_source_handler_gnd
 
-        for pdutype in pdus:
-            self.src.state_machine()
-            self.dst.state_machine()
+    # @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
+    # def test_missing_ack(self):
+    #     """What happens if the first ack gets dropped?"""
+    #     # src --> Metadata
+    #     # src --> FileData
+    #     # src --> EoF
+    #     # dst  X  Ack (EoF)
+    #     # dst <-- Finished
+    #     # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
+    #     # src --> EoF
+    #     # dst <-- Ack (EoF)
+    #     # dst <-- Finished
+    #     # src --> Ack (Finished)
+    #     pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
 
-            while self.src.packets_ready:
-                pdu = self.src.get_next_packet().pdu
-                self.assertIsInstance(pdu, pdutype)
-                self.dst.state_machine(pdu)
+    #     put = put_request(self.dst_id, self.file.name)
+    #     self.assertTrue(self.src.put_request(put))
 
-            while self.dst.packets_ready:
-                pdu = self.dst.get_next_packet().pdu
-                self.assertIsInstance(pdu, pdutype)
-                self.src.state_machien(pdu)
+    #     for i, pdutype in enumerate(pdus):
+    #         self.src.state_machine()
+    #         self.dst.state_machine()
 
-        self.src.state_machine()
-        self.dst.state_machine()
+    #         print("SRC:", self.src.step, "| DST:", self.src.step)
 
-        self.assertEqual(self.src.step, source.TransactionStep.IDLE)
-        self.assertEqual(self.dst.step, dest.TransactionStep.IDLE)
+    #         while self.src.packets_ready:
+    #             pdu = self.src.get_next_packet().pdu
+    #             print("\nSRC ", pdu, "\n")
+    #             self.assertIsInstance(pdu, pdutype)
+    #             self.dst.state_machine(pdu)
 
-    @unittest.skip("FIXME: Revisit this after upgrading cfdppy to 0.6.0")
-    def test_missing_ack(self):
-        """What happens if the first ack gets dropped?"""
-        # src --> Metadata
-        # src --> FileData
-        # src --> EoF
-        # dst  X  Ack (EoF)
-        # dst <-- Finished
-        # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
-        # src --> EoF
-        # dst <-- Ack (EoF)
-        # dst <-- Finished
-        # src --> Ack (Finished)
-        pdus = [MetadataPdu, FileDataPdu, EofPdu, AckPdu, FinishedPdu, AckPdu]
+    #         while self.dst.packets_ready:
+    #             pdu = self.dst.get_next_packet().pdu
+    #             self.assertIsInstance(pdu, pdutype)
+    #             if i == 3:  # Skip first Ack
+    #                 break
+    #             print("\nSRC ", pdu, "\n")
+    #             with self.assertRaises(PduIgnoredForSource):
+    #                 self.src.state_machine(pdu)
 
-        put = put_request(self.dst_id, self.file.name)
-        self.assertTrue(self.src.put_request(put))
+    #     self.src.state_machine()
+    #     self.dst.state_machine()
 
-        for i, pdutype in enumerate(pdus):
-            self.src.state_machine()
-            self.dst.state_machine()
-
-            print("SRC:", self.src.step, "| DST:", self.src.step)
-
-            while self.src.packets_ready:
-                pdu = self.src.get_next_packet().pdu
-                print("\nSRC ", pdu, "\n")
-                self.assertIsInstance(pdu, pdutype)
-                self.dst.state_machine(pdu)
-
-            while self.dst.packets_ready:
-                pdu = self.dst.get_next_packet().pdu
-                self.assertIsInstance(pdu, pdutype)
-                if i == 3:  # Skip first Ack
-                    break
-                print("\nSRC ", pdu, "\n")
-                with self.assertRaises(PduIgnoredForSource):
-                    self.src.state_machine(pdu)
-
-        self.src.state_machine()
-        self.dst.state_machine()
-
-        self.assertEqual(self.src.step, source.TransactionStep.IDLE)
-        self.assertEqual(self.dst.step, dest.TransactionStep.IDLE)
+    #     self.assertEqual(self.src.step, source.TransactionStep.IDLE)
+    #     self.assertEqual(self.dst.step, dest.TransactionStep.IDLE)
 
 
 #

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -55,7 +55,7 @@ def put_request(destination: ByteFieldU8, file_path: str) -> PutRequest:
         source_file=Path(file_path),
         dest_file=Path(file_path),
         trans_mode=None,
-        closure_requested=None,
+        closure_requested=True,
     )
 
 
@@ -85,7 +85,7 @@ class TestCfdp(unittest.TestCase):
                     # How does the exact value get determined? Currently it's just a mirror of the
                     # value in edl_file_upload.py
                     max_packet_len=950,
-                    closure_requested=False,
+                    closure_requested=True,
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
                     crc_type=ChecksumType.MODULAR,
@@ -127,7 +127,7 @@ class TestCfdp(unittest.TestCase):
                     # How does the exact value get determined? Currently it's just a mirror of the
                     # value in edl_file_upload.py
                     max_packet_len=950,
-                    closure_requested=False,
+                    closure_requested=True,
                     crc_on_transmission=False,
                     default_transmission_mode=TransmissionMode.ACKNOWLEDGED,
                     crc_type=ChecksumType.MODULAR,
@@ -180,18 +180,21 @@ class TestCfdp(unittest.TestCase):
 
         self._put_req_queue_gnd.put(put)
 
+        # src --> Metadata
         time.sleep(0.2)
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
         self.assertIsInstance(pdu.pdu, MetadataPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
+        # src --> Filedata
         time.sleep(0.15)
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
         self.assertIsInstance(pdu.pdu, FileDataPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
+        # src --> EoF
         time.sleep(0.15)
         pdu_packed = self._cfdp_tm_queue_gnd.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
@@ -199,6 +202,7 @@ class TestCfdp(unittest.TestCase):
         self.assertIsInstance(pdu.pdu, EofPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
+        # dst <-- Ack (EoF)
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         pdu_packed = self._cfdp_tm_queue.get()
@@ -206,12 +210,14 @@ class TestCfdp(unittest.TestCase):
         self.assertIsInstance(pdu.pdu, AckPdu)
         self._cfdp_src_queue_gnd.put(pdu.pdu)
 
+        # dst <-- Finished
         time.sleep(0.15)
         pdu_packed = self._cfdp_tm_queue.get()
         pdu = PduFactory.from_raw_to_holder(pdu_packed)
         self.assertIsInstance(pdu.pdu, FinishedPdu)
         self._cfdp_src_queue_gnd.put(pdu.pdu)
 
+        # src --> Ack (Finished)
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue.empty())
         pdu_packed = self._cfdp_tm_queue_gnd.get()
@@ -219,6 +225,99 @@ class TestCfdp(unittest.TestCase):
         self.assertIsInstance(pdu.pdu, AckPdu)
         self._cfdp_dest_queue.put(pdu.pdu)
 
+        # Make sure we've returned to idle / empty.
+        time.sleep(1)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+        self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
+        self.assertEqual(
+            self.cfdp_source_handler_gnd.source_handler.step,
+            source.TransactionStep.IDLE
+        )
+
+    # Broken for now. For some reason CFDP stops resending EOFs after recieving a finished PDU,
+    # leaving it stuck waiting for an ACK (EOF) without resending EOFs.
+    def test_dropped_ack(self):
+        """What happens if the first ack gets dropped?"""
+        # src --> Metadata
+        # src --> FileData
+        # src --> EoF
+        # dst  X  Ack (EoF)
+        # dst <-- Finished
+        # ??? According to 4.7.1 b) the origional PDU should be re-issued. So:
+        # src --> EoF
+        # dst <-- Ack (EoF)
+        # dst <-- Finished
+        # src --> Ack (Finished)
+
+        put = put_request(self.sat_id, self.file.name)
+
+        self._put_req_queue_gnd.put(put)
+
+        # src --> Metadata
+        time.sleep(0.2)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, MetadataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # src --> Filedata
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FileDataPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # src --> EoF
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue_gnd.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        print(get_packet_destination(pdu.pdu))
+        self.assertIsInstance(pdu.pdu, EofPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # dst <-- Ack (EoF)
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue_gnd.empty())
+        pdu_packed = self._cfdp_tm_queue.get()
+
+        # dst <-- Finished
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+        time.sleep(1)
+
+        print(self.cfdp_source_handler_gnd.source_handler.step)
+
+        time.sleep(10)
+
+        # dst <-- Finished
+        time.sleep(0.15)
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, FinishedPdu)
+        self._cfdp_src_queue_gnd.put(pdu.pdu)
+        time.sleep(1)
+
+        print(self.cfdp_source_handler_gnd.source_handler.step)
+
+        time.sleep(100)
+
+        # src --> Ack (Finished)
+        time.sleep(0.15)
+        self.assertTrue(self._cfdp_tm_queue.empty())
+        pdu_packed = self._cfdp_tm_queue.get()
+        pdu = PduFactory.from_raw_to_holder(pdu_packed)
+        self.assertIsInstance(pdu.pdu, AckPdu)
+        self._cfdp_dest_queue.put(pdu.pdu)
+
+        # Make sure we've returned to idle / empty.
         time.sleep(1)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
@@ -291,3 +390,4 @@ class TestCfdp(unittest.TestCase):
 #                    pdu = self.src.get_next_packet().pdu
 #                    self.uplink.put(pdu)
 #
+

--- a/tests/protocols/test_cfdp.py
+++ b/tests/protocols/test_cfdp.py
@@ -99,7 +99,7 @@ class TestCfdp(unittest.TestCase):
             remote_entities,
             self.gnd_id,
             self.sat_id,
-            self.stop_signal
+            self.stop_signal,
         )
         self.cfdp_dest_handler = DestEntityHandler(
             self._put_req_queue,
@@ -108,7 +108,7 @@ class TestCfdp(unittest.TestCase):
             self.cache,
             remote_entities,
             self.sat_id,
-            self.stop_signal
+            self.stop_signal,
         )
 
         # Ground station handling
@@ -140,7 +140,7 @@ class TestCfdp(unittest.TestCase):
             remote_entities_gnd,
             self.sat_id,
             self.gnd_id,
-            self.stop_signal
+            self.stop_signal,
         )
         self.cfdp_dest_handler_gnd = DestEntityHandler(
             self._put_req_queue_gnd,
@@ -149,7 +149,7 @@ class TestCfdp(unittest.TestCase):
             self.cache_gnd,
             remote_entities_gnd,
             self.gnd_id,
-            self.stop_signal
+            self.stop_signal,
         )
 
         self.cfdp_source_handler.start()
@@ -198,19 +198,14 @@ class TestCfdp(unittest.TestCase):
         time.sleep(1)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
-            self.cfdp_source_handler_gnd.source_handler.step,
-            source.TransactionStep.IDLE
+            self.cfdp_source_handler_gnd.source_handler.step, source.TransactionStep.IDLE
         )
         self.assertEqual(
-            self.cache.read_data(self.gnd_file),
-            self.cache_gnd.read_data(self.gnd_file, None)
+            self.cache.read_data(self.gnd_file), self.cache_gnd.read_data(self.gnd_file, None)
         )
         self.cache.delete_file(self.gnd_file)
 
@@ -241,7 +236,7 @@ class TestCfdp(unittest.TestCase):
         # dst X-- Ack (EoF)
         time.sleep(0.15)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        self._cfdp_tm_queue.get() # drop the pdu
+        self._cfdp_tm_queue.get()  # drop the pdu
         # dst <-- Finished
         self._dest_sc_to_gnd_src(0.15, FinishedPdu)
         # A timeout will occur here.
@@ -258,19 +253,14 @@ class TestCfdp(unittest.TestCase):
         time.sleep(1)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
-            self.cfdp_source_handler_gnd.source_handler.step,
-            source.TransactionStep.IDLE
+            self.cfdp_source_handler_gnd.source_handler.step, source.TransactionStep.IDLE
         )
         self.assertEqual(
-            self.cache.read_data(self.gnd_file),
-            self.cache_gnd.read_data(self.gnd_file, None)
+            self.cache.read_data(self.gnd_file), self.cache_gnd.read_data(self.gnd_file, None)
         )
         self.cache.delete_file(self.gnd_file)
 
@@ -302,7 +292,7 @@ class TestCfdp(unittest.TestCase):
             ProxyPutRequestParams(
                 dest_entity_id=self.gnd_id,
                 source_file_name=CfdpLv.from_str(self.sat_file.name),
-                dest_file_name=CfdpLv.from_str(self.sat_file.name)
+                dest_file_name=CfdpLv.from_str(self.sat_file.name),
             )
         ).to_generic_msg_to_user_tlv()
         # Yamcs will always send a proxy transmission mode message, for both class 1 or class 2.
@@ -362,19 +352,14 @@ class TestCfdp(unittest.TestCase):
         time.sleep(1)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
-            self.cfdp_source_handler_gnd.source_handler.step,
-            source.TransactionStep.IDLE
+            self.cfdp_source_handler_gnd.source_handler.step, source.TransactionStep.IDLE
         )
         self.assertEqual(
-            self.cache.read_data(self.sat_file),
-            self.cache_gnd.read_data(self.sat_file, None)
+            self.cache.read_data(self.sat_file), self.cache_gnd.read_data(self.sat_file, None)
         )
         self.cache_gnd.delete_file(self.sat_file)
 
@@ -411,8 +396,7 @@ class TestCfdp(unittest.TestCase):
         dir_listing_gnd = ".dirlist.notsaved"
         dir_req = DirectoryListingRequest(
             DirectoryParams(
-                dir_path=CfdpLv.from_str(""),
-                dir_file_name=CfdpLv.from_str(dir_listing_gnd)
+                dir_path=CfdpLv.from_str(""), dir_file_name=CfdpLv.from_str(dir_listing_gnd)
             )
         ).to_generic_msg_to_user_tlv()
         put = PutRequest(
@@ -467,19 +451,15 @@ class TestCfdp(unittest.TestCase):
         time.sleep(1)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
-            self.cfdp_source_handler_gnd.source_handler.step,
-            source.TransactionStep.IDLE
+            self.cfdp_source_handler_gnd.source_handler.step, source.TransactionStep.IDLE
         )
         self.assertEqual(
             self.cache.read_data(Path(dir_listing_gnd)),
-            self.cache_gnd.read_data(Path(dir_listing_gnd), None)
+            self.cache_gnd.read_data(Path(dir_listing_gnd), None),
         )
         self.cache.delete_file(Path(dir_listing_gnd))
         self.cache_gnd.delete_file(Path(dir_listing_gnd))
@@ -509,11 +489,11 @@ class TestCfdp(unittest.TestCase):
         # src --> EoF
         self._src_gnd_to_sc_dest(0.15, EofPdu)
 
-        self._cfdp_tm_queue.get() # drop the ack(eof)
-        self._cfdp_tm_queue.get() # drop the fin
+        self._cfdp_tm_queue.get()  # drop the ack(eof)
+        self._cfdp_tm_queue.get()  # drop the fin
         self.assertEqual(
             self.cfdp_source_handler_gnd.source_handler.step,
-            source.TransactionStep.WAITING_FOR_EOF_ACK
+            source.TransactionStep.WAITING_FOR_EOF_ACK,
         )
         self.assertEqual(
             self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.WAITING_FOR_FINISHED_ACK
@@ -534,10 +514,7 @@ class TestCfdp(unittest.TestCase):
         self.assertIsInstance(pdu.pdu, FinishedPdu)
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
         self.assertEqual(
             self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.WAITING_FOR_FINISHED_ACK
         )
@@ -551,28 +528,19 @@ class TestCfdp(unittest.TestCase):
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         time.sleep(self.TIMEOUT_DUR + 0.02)
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
-        self.assertEqual(
-            self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
+        self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
         time.sleep(self.TIMEOUT_DUR * 2 + 0.02)
 
         # Make sure we've returned to idle / empty.
         time.sleep(1)
         self.assertTrue(self._cfdp_tm_queue_gnd.empty())
         self.assertEqual(self.cfdp_dest_handler.dest_handler.step, dest.TransactionStep.IDLE)
-        self.assertEqual(
-            self.cfdp_source_handler.source_handler.step,
-            source.TransactionStep.IDLE
-        )
+        self.assertEqual(self.cfdp_source_handler.source_handler.step, source.TransactionStep.IDLE)
         self.assertTrue(self._cfdp_tm_queue.empty())
         self.assertEqual(self.cfdp_dest_handler_gnd.dest_handler.step, dest.TransactionStep.IDLE)
         self.assertEqual(
-            self.cfdp_source_handler_gnd.source_handler.step,
-            source.TransactionStep.IDLE
+            self.cfdp_source_handler_gnd.source_handler.step, source.TransactionStep.IDLE
         )
 
     def _src_gnd_to_sc_dest(self, delay: float, expected_type: ABCMeta) -> None:


### PR DESCRIPTION
Reworks cfdp to be handled by 4 queues and 2 separate threads, based on the example implementation in the cfdp package.

- `put_req_queue`sends put requests to the source handler, being either new put requests originating on the satellite or transactions within a larger operation, e.g. the second two transactions of a proxy put request.
- `_cfdp_tm_queue` is the queue of pdus that should be sent to the ground station from both the source and dest handlers.
- `_cfdp_src_queue` and `_cfdp_dest_queue` are the queues received pdus, once they have been taken out of the uslp frame and the destination has been determined.

In addition, I have modified ThirteenFish's preliminary cfdp unit test file so that it now contains unit tests for sending a file from the "ground station" to the satellite, sending the same file but with the EOF ack getting dropped, sending a proxy put request (and the corresponding 2 addition transactions), and sending a cfdp directory listing request (and the corresponding two additional transactions).

The cachestore has been modified to allow successful directory listing requests, although I do not like the current implementation as it has to hack around the oresat_file naming conventions to have the directory list file preserved between the first two transactions. CFDP is also only able to access the fwrite cache, so I think that cachestore should be rewritten to allow sub directories and also to handle this case much more cleanly.


At present, the following issues mean that this is not ready to be merged. I will not have much time to fix the in the immediate future, and so contributions by those interested to resolve them would be appreciated.

- The c3 software talking to YAMCS (on the same computer) successfully completes the first two transactions of a proxy put or directory listing request, but fails the third and final transaction.
- Suspension of the current transaction can lead to cfdp sending endless cancel pdus.
- The directory listing request sends the result of an ls -al command, which yamcs cannot handle and therefore YAMCS can never read the directory listing file. The file should be redefined to be compatible with YAMCS.
- It should be possible to optimize the power use of the cfdp threads, either by making the cfpd threads sleep until the c3-state becomes EDL, or by tuning the sleep timeouts.