### PR TITLE
Add FOP-1 routing and management

### DIFF
--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -92,6 +92,7 @@ def make_frame(
     control_word: Optional[bytes] = None,
     sequence_number: int = 0,
     bypass: bool = False,
+    command: bool = False,
 ) -> TransferFrame:
     """Create and pack a USLP
 
@@ -113,6 +114,8 @@ def make_frame(
         The anti-replay sequence number for SDLS.
     bypass
         Specify if this frame is bypass (Type-BD) frame.
+    command
+        Specify if this frame is for protocol command.
 
     Returns
     -------
@@ -126,6 +129,8 @@ def make_frame(
         # Needs to be this, yamcs does not support user defined octet stream and this functions.
         tfdz=payload,
     )
+
+    vcf_count_len = 1 if vcf_count is not None else 0
 
     # USLP transfer frame total length - 1
     frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
@@ -146,10 +151,14 @@ def make_frame(
         vcid=vcid,
         src_dest=src_dest,
         frame_len=frame_len,
-        vcf_count_len=bool(vcf_count),
+        vcf_count_len=vcf_count_len,
         vcf_count=vcf_count,
         op_ctrl_flag=has_clcw,
-        prot_ctrl_cmd_flag=ProtocolCommandFlag.USER_DATA,
+        prot_ctrl_cmd_flag=(
+            ProtocolCommandFlag.PROTOCOL_INFORMATION
+            if command
+            else ProtocolCommandFlag.USER_DATA
+        ),
         bypass_seq_ctrl_flag=(
             BypassSequenceControlFlag.EXPEDITED_QOS
             if bypass

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -65,9 +65,8 @@ def unpack_frame(raw: bytes) -> TransferFrame:
 
     vcid = ((raw[2] & 0b111) << 3) | ((raw[3] >> 5) & 0b111)
 
-    # bypass frames never have an SDLS insert zone
-    is_bypass = bool(raw[6] & 0x80)
-    sdls_header_len = 0 if is_bypass else get_sdls_header_len(vcid)
+    is_command = bool(raw[6] & 0x40)
+    sdls_header_len = 0 if is_command else get_sdls_header_len(vcid)
 
     frame_props = VarFrameProperties(
         has_insert_zone=sdls_header_len != 0,
@@ -140,7 +139,7 @@ def make_frame(
     frame_len = len(payload) + PRIMARY_HEADER_LEN + vcf_count_len + DFH_LEN + FECF_LEN - 1
     if has_clcw:
         frame_len += len(control_word)
-    if not bypass:
+    if not command:
         frame_len += get_sdls_len(vcid)
 
     frame_header = PrimaryHeader(
@@ -164,7 +163,7 @@ def make_frame(
 
     frame = TransferFrame(header=frame_header, tfdf=tfdf, op_ctrl_field=control_word)
 
-    if not bypass:
+    if not command:
         apply_sdls(frame, sequence_number, hmac_key)
 
     return frame

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -153,9 +153,7 @@ def make_frame(
         vcf_count=vcf_count,
         op_ctrl_flag=has_clcw,
         prot_ctrl_cmd_flag=(
-            ProtocolCommandFlag.PROTOCOL_INFORMATION
-            if command
-            else ProtocolCommandFlag.USER_DATA
+            ProtocolCommandFlag.PROTOCOL_INFORMATION if command else ProtocolCommandFlag.USER_DATA
         ),
         bypass_seq_ctrl_flag=(
             BypassSequenceControlFlag.EXPEDITED_QOS

--- a/oresat_c3/protocols/uslp.py
+++ b/oresat_c3/protocols/uslp.py
@@ -65,7 +65,9 @@ def unpack_frame(raw: bytes) -> TransferFrame:
 
     vcid = ((raw[2] & 0b111) << 3) | ((raw[3] >> 5) & 0b111)
 
-    sdls_header_len = get_sdls_header_len(vcid)
+    # bypass frames never have an SDLS insert zone
+    is_bypass = bool(raw[6] & 0x80)
+    sdls_header_len = 0 if is_bypass else get_sdls_header_len(vcid)
 
     frame_props = VarFrameProperties(
         has_insert_zone=sdls_header_len != 0,
@@ -132,18 +134,14 @@ def make_frame(
 
     vcf_count_len = 1 if vcf_count is not None else 0
 
-    # USLP transfer frame total length - 1
-    frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
-
     has_clcw = control_word is not None
-    if has_clcw:
-        frame_len += len(control_word)
 
     # USLP transfer frame total length - 1
-    frame_len = len(payload) + PRIMARY_HEADER_LEN + DFH_LEN + FECF_LEN - 1
+    frame_len = len(payload) + PRIMARY_HEADER_LEN + vcf_count_len + DFH_LEN + FECF_LEN - 1
     if has_clcw:
         frame_len += len(control_word)
-    frame_len += get_sdls_len(vcid)
+    if not bypass:
+        frame_len += get_sdls_len(vcid)
 
     frame_header = PrimaryHeader(
         scid=SPACECRAFT_ID,
@@ -168,6 +166,7 @@ def make_frame(
 
     frame = TransferFrame(header=frame_header, tfdf=tfdf, op_ctrl_field=control_word)
 
-    apply_sdls(frame, sequence_number, hmac_key)
+    if not bypass:
+        apply_sdls(frame, sequence_number, hmac_key)
 
     return frame

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -81,9 +81,7 @@ class ChannelRouterService(Service):
                 src_dest=SourceOrDestField.SOURCE,
                 control_word=clcw.pack(),
             )
-            self._radios_service.send_edl_response(
-                frame.pack(frame_type=FrameType.VARIABLE)
-            )
+            self._radios_service.send_edl_response(frame.pack(frame_type=FrameType.VARIABLE))
 
     def request_uplink_route(
         self, vcid: EdlVcid, use_cop: bool = False
@@ -117,13 +115,15 @@ class ChannelRouterService(Service):
             self._uplink_routes[vcid] = q
         return q
 
-    def request_downlink_route(self, vcid: EdlVcid) -> SimpleQueue[bytes]:
+    def request_downlink_route(self, vcid: EdlVcid, use_cop: bool = False) -> SimpleQueue[bytes]:
         """Request a downlink Virtual Channel route.
 
         Parameters
         ----------
         vcid
             The VCID used to identify the route.
+        use_cop
+            True enables COP-1 (FOP-1) on this route.
 
         Returns
         -------
@@ -138,11 +138,14 @@ class ChannelRouterService(Service):
 
         if vcid in self._downlink_routes:
             raise KeyError(f"Downlink route for VCID={vcid} already exists")
+        if use_cop:
+            send_queue: SimpleQueue[bytes] = SimpleQueue()
+            q = self._cop_service.create_fop_service(vcid, send_queue)
+            self._downlink_routes[vcid] = send_queue
         else:
-            q: SimpleQueue[bytes] = SimpleQueue()
+            q = SimpleQueue()
             self._downlink_routes[vcid] = q
-            logger.info(f"Created downlink route for VCID {vcid}")
-            return q
+        return q
 
     def _get_all_clcw(self) -> list[ControlWord]:
         clcws = []

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -63,7 +63,7 @@ class ChannelRouterService(Service):
             if frame.op_ctrl_field is not None:
                 self._cop_service.dispatch_clcw(ControlWord.unpack(frame.op_ctrl_field))
             vcid = frame.header.vcid
-            if vcid in self._uplink_routes:
+            if vcid != EdlVcid.IDLE and vcid in self._uplink_routes:
                 self._uplink_routes[vcid].put_nowait(frame)
             else:
                 logger.error(f"No route for VCID {frame.header.vcid}")

--- a/oresat_c3/services/channel_router.py
+++ b/oresat_c3/services/channel_router.py
@@ -35,6 +35,9 @@ class ChannelRouterService(Service):
         self._downlink_routes: dict[EdlVcid, SimpleQueue[bytes]] = {}
         self._last_clcw_time = 0.0
 
+    def on_start(self) -> None:
+        self._send_clcws()
+
     def on_loop(self) -> None:
         for dl in self._downlink_routes.values():
             while True:
@@ -47,16 +50,7 @@ class ChannelRouterService(Service):
         if self.node.od["status"].value == C3State.EDL:
             now = monotonic()
             if now - self._last_clcw_time >= self._CLCW_INTERVAL:
-                for clcw in self._get_all_clcw():
-                    frame = make_frame(
-                        payload=bytes(1),
-                        vcid=EdlVcid.IDLE,
-                        src_dest=SourceOrDestField.SOURCE,
-                        control_word=clcw.pack(),
-                    )
-                    self._radios_service.send_edl_response(
-                        frame.pack(frame_type=FrameType.VARIABLE)
-                    )
+                self._send_clcws()
                 self._last_clcw_time = now
 
         try:
@@ -66,6 +60,8 @@ class ChannelRouterService(Service):
 
         try:
             frame = unpack_frame(message)
+            if frame.op_ctrl_field is not None:
+                self._cop_service.dispatch_clcw(ControlWord.unpack(frame.op_ctrl_field))
             vcid = frame.header.vcid
             if vcid in self._uplink_routes:
                 self._uplink_routes[vcid].put_nowait(frame)
@@ -76,6 +72,18 @@ class ChannelRouterService(Service):
             logger.debug(message)
         except Exception as e:
             logger.exception(f"Failed to unpack frame: {e}")
+
+    def _send_clcws(self) -> None:
+        for clcw in self._get_all_clcw():
+            frame = make_frame(
+                payload=bytes(1),
+                vcid=EdlVcid.IDLE,
+                src_dest=SourceOrDestField.SOURCE,
+                control_word=clcw.pack(),
+            )
+            self._radios_service.send_edl_response(
+                frame.pack(frame_type=FrameType.VARIABLE)
+            )
 
     def request_uplink_route(
         self, vcid: EdlVcid, use_cop: bool = False

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -61,7 +61,7 @@ class CopManagerService(Service):
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")
         q: SimpleQueue[TransferFrame] = SimpleQueue()
-        self._farms[vcid] = (Farm1(w=20, vcf_count_length=2), q)
+        self._farms[vcid] = (Farm1(w=20, vcf_count_length=1), q)
         return q
 
     def get_service(self, vcid: EdlVcid) -> Optional[CopService]:

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -17,6 +17,8 @@ from ccsds_cop.cop_1.fop import (
     AsyncNotification,
     AsyncNotificationType,
     DirectiveNotification,
+    DirectiveRequest,
+    DirectiveType,
     Fop1,
     NotificationType,
     RequestToTransferFdu,
@@ -59,11 +61,13 @@ class FopSupervisorState(Enum):
 @dataclass
 class FopInstance:
     service: Fop1
+    gvcid: Gvcid
     fdu_queue: SimpleQueue[bytes]
     send_queue: SimpleQueue[bytes]
     requests: set[int] = field(default_factory=set)
     state: FopSupervisorState = FopSupervisorState.IDLE
-    _next_rid = 0
+    last_nr: int = 0
+    _next_rid: int = 0
 
     def next_rid(self) -> int:
         rid = self._next_rid
@@ -76,6 +80,8 @@ class CopManagerService(Service):
     This service acts as both the Higher and Lower procedures for any number of FARM-1
     or FOP-1 COP-1 services
     """
+
+    MAX_RECOVERY_ATTEMPTS = 3
 
     def __init__(self) -> None:
         super().__init__()
@@ -142,12 +148,12 @@ class CopManagerService(Service):
                     logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
 
     def _process_fop_higher(self) -> None:
-        for vcid, instance in self._fops.items():
+        for instance in self._fops.values():
             instance.service.drain_timer_events()
             for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
                 instance.service.on_receive_request_to_transfer_fdu(
                     RequestToTransferFdu(
-                        gvcid=Gvcid(0b1100, SPACECRAFT_ID, vcid),
+                        gvcid=instance.gvcid,
                         request_id=instance.next_rid(),
                         fdu=fdu,
                         service_type=ServiceType.BD
@@ -163,7 +169,10 @@ class CopManagerService(Service):
                         # TODO: notify the user
                         instance.requests.remove(i.request_id)
                     elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
-                        if instance.state == FopSupervisorState.RECOVERING:
+                        if instance.state in (
+                            FopSupervisorState.RECOVERING,
+                            FopSupervisorState.INITIATING,
+                        ):
                             instance.state = FopSupervisorState.ACTIVE
                         instance.requests.remove(i.request_id)
                     elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
@@ -190,20 +199,47 @@ class CopManagerService(Service):
             instance = self._fops.get(EdlVcid(clcw.vcid))
             if instance is not None:
                 if instance.state in (FopSupervisorState.IDLE, FopSupervisorState.SUSPENDED):
-                    # TODO: send INITIATE_AD_WITH_SET_V_R directive
+                    instance.service.on_receive_directive(
+                        DirectiveRequest(
+                            gvcid=instance.gvcid,
+                            request_id=instance.next_rid(),
+                            directive_type=DirectiveType.INITIATE_AD_WITH_SET_V_R,
+                            directive_qualifier=clcw.report_value,
+                        )
+                    )
                     instance.state = FopSupervisorState.INITIATING
                 instance.service.on_clcw_arrived(clcw)
+                instance.last_nr = clcw.report_value
             else:
                 logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")
 
     def _recover(self, instance: FopInstance, alert: Alert) -> None:
         instance.state = FopSupervisorState.RECOVERING
         if alert == Alert.LOCKOUT:
-            pass  # init ad with unlock
+            instance.service.on_receive_directive(
+                DirectiveRequest(
+                    gvcid=instance.gvcid,
+                    request_id=instance.next_rid(),
+                    directive_type=DirectiveType.INITIATE_AD_WITH_UNLOCK,
+                )
+            )
         elif alert in (Alert.SYNCH, Alert.NNR, Alert.CLCW):
-            pass  # init ad with set vr (from last CLCW)
+            instance.service.on_receive_directive(
+                DirectiveRequest(
+                    gvcid=instance.gvcid,
+                    request_id=instance.next_rid(),
+                    directive_type=DirectiveType.INITIATE_AD_WITH_SET_V_R,
+                    directive_qualifier=instance.last_nr,
+                )
+            )
         elif alert in (Alert.LIMIT, Alert.T1, Alert.LLIF):
-            pass  # init with clcw
+            instance.service.on_receive_directive(
+                DirectiveRequest(
+                    gvcid=instance.gvcid,
+                    request_id=instance.next_rid(),
+                    directive_type=DirectiveType.INITIATE_AD_WITH_CLCW,
+                )
+            )
         elif alert == Alert.TERM:
             # unrecoverable: go to IDLE
             instance.state = FopSupervisorState.IDLE
@@ -233,8 +269,10 @@ class CopManagerService(Service):
         """
         logger.info(f"Creating FOP-1 Service for VCID {vcid}")
         q: SimpleQueue[bytes] = SimpleQueue()
+        gvcid = Gvcid(0b1100, SPACECRAFT_ID, vcid)
         self._fops[vcid] = FopInstance(
-            service=Fop1(Gvcid(0b1100, SPACECRAFT_ID, vcid)),
+            service=Fop1(gvcid=gvcid),
+            gvcid=gvcid,
             fdu_queue=q,
             send_queue=send_queue,
         )

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from queue import Empty, SimpleQueue
 from typing import Optional
 
-from ccsds_cop.cop_1 import CopService, Gvcid
+from ccsds_cop.cop_1 import ControlWord, CopService, Gvcid
 from ccsds_cop.cop_1.farm import (
     Farm1,
     FarmHigherServiceInterface,
@@ -37,6 +37,7 @@ class FopInstance:
         rid = self._next_rid
         self._next_rid += 1
         return rid
+
 
 class CopManagerService(Service):
     """COP-1 Services Manager
@@ -132,12 +133,19 @@ class CopManagerService(Service):
                 elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
                     pass
 
-
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")
         q: SimpleQueue[TransferFrame] = SimpleQueue()
         self._farms[vcid] = (Farm1(w=20, vcf_count_length=1), q)
         return q
+
+    def dispatch_clcw(self, clcw: ControlWord) -> None:
+        """Hand a control word to the COP Manager for automatic routing to a FOP-1 instance."""
+        instance = self._fops.get(clcw.vcid)
+        if instance is not None:
+            instance.service.on_clcw_arrived(clcw)
+        else:
+            logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")
 
     def get_service(self, vcid: EdlVcid) -> Optional[CopService]:
         entry = self._farms.get(vcid)

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -98,8 +98,9 @@ class CopManagerService(Service):
         self._process_farm_higher()
         self._process_farm_lower()
         self._process_clcw()
-        self._process_fop_higher()
-        self._process_fop_lower()
+        for instance in self._fops.values():
+            self._process_fop_higher(instance)
+            self._process_fop_lower(instance)
         self.sleep_ms(50)
 
     def _process_farm_lower(self) -> None:
@@ -130,85 +131,81 @@ class CopManagerService(Service):
             except IndexError:
                 continue
 
-    def _process_fop_lower(self) -> None:
-        for instance in self._fops.values():
-            for i in _drain(instance.service.interface.to_lower.pop, IndexError):
-                if isinstance(i, TransmitRequestForFrame):
-                    fr = make_frame(
-                        payload=i.tfdf,
-                        vcid=i.gvcid.vcid,
-                        src_dest=SourceOrDestField.SOURCE,
-                        vcf_count=i.v_s
-                        if i.bypass_flag == BypassSequenceControlFlag.SEQ_CTRLD_QOS
-                        else None,
-                        bypass=i.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS,
-                        command=i.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
-                    )
-                    instance.send_queue.put_nowait(fr.pack(FrameType.VARIABLE))
-                elif isinstance(i, AbortRequest):
-                    for _ in _drain(instance.send_queue.get_nowait, Empty):
-                        pass
-                else:
-                    logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
+    def _process_fop_lower(self, instance: FopInstance) -> None:
+        for i in _drain(instance.service.interface.to_lower.pop, IndexError):
+            if isinstance(i, TransmitRequestForFrame):
+                fr = make_frame(
+                    payload=i.tfdf,
+                    vcid=i.gvcid.vcid,
+                    src_dest=SourceOrDestField.SOURCE,
+                    vcf_count=i.v_s
+                    if i.bypass_flag == BypassSequenceControlFlag.SEQ_CTRLD_QOS
+                    else None,
+                    bypass=i.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS,
+                    command=i.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
+                )
+                instance.send_queue.put_nowait(fr.pack(FrameType.VARIABLE))
+            elif isinstance(i, AbortRequest):
+                for _ in _drain(instance.send_queue.get_nowait, Empty):
+                    pass
+            else:
+                logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
 
-    def _process_fop_higher(self) -> None:
-        for instance in self._fops.values():
-            instance.service.drain_timer_events()
-            if (
-                instance.state == FopSupervisorState.BD_FALLBACK
-                and time.monotonic() >= instance.init_retry_at
-            ):
-                instance.service.on_receive_directive(
-                    DirectiveRequest(
+    def _process_fop_higher(self, instance: FopInstance) -> None:
+        instance.service.drain_timer_events()
+        if (
+            instance.state == FopSupervisorState.BD_FALLBACK
+            and time.monotonic() >= instance.init_retry_at
+        ):
+            instance.service.on_receive_directive(
+                DirectiveRequest(
+                    gvcid=instance.gvcid,
+                    request_id=instance.next_rid(),
+                    directive_type=DirectiveType.INITIATE_AD_WITH_SET_V_R,
+                    directive_qualifier=instance.last_nr,
+                )
+            )
+            instance.state = FopSupervisorState.INITIATING
+        if instance.state in (FopSupervisorState.ACTIVE, FopSupervisorState.BD_FALLBACK):
+            for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
+                instance.service.on_receive_request_to_transfer_fdu(
+                    RequestToTransferFdu(
                         gvcid=instance.gvcid,
                         request_id=instance.next_rid(),
-                        directive_type=DirectiveType.INITIATE_AD_WITH_SET_V_R,
-                        directive_qualifier=instance.last_nr,
-                    )
+                        fdu=fdu,
+                        service_type=ServiceType.BD
+                        if instance.state == FopSupervisorState.BD_FALLBACK
+                        else ServiceType.AD,
+                    ),
                 )
-                instance.state = FopSupervisorState.INITIATING
-            if instance.state in (FopSupervisorState.ACTIVE, FopSupervisorState.BD_FALLBACK):
-                for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
-                    instance.service.on_receive_request_to_transfer_fdu(
-                        RequestToTransferFdu(
-                            gvcid=instance.gvcid,
-                            request_id=instance.next_rid(),
-                            fdu=fdu,
-                            service_type=ServiceType.BD
-                            if instance.state == FopSupervisorState.BD_FALLBACK
-                            else ServiceType.AD,
-                        ),
+        for i in _drain(instance.service.interface.to_higher.pop, IndexError):
+            if isinstance(i, DirectiveNotification):
+                if i.notification_type == NotificationType.ACCEPT:
+                    instance.requests.add(i.request_id)
+                elif i.notification_type == NotificationType.REJECT:
+                    instance.requests.discard(i.request_id)
+                elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
+                    if instance.state in (
+                        FopSupervisorState.RECOVERING,
+                        FopSupervisorState.INITIATING,
+                    ):
+                        instance.state = FopSupervisorState.ACTIVE
+                        instance.recovery_attempts = 0
+                    instance.requests.discard(i.request_id)
+                elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
+                    instance.requests.discard(i.request_id)
+            elif isinstance(i, AsyncNotification):
+                if i.notification_type == AsyncNotificationType.ALERT:
+                    self._recover(instance, i.notification_qualifier)
+                elif i.notification_type == AsyncNotificationType.SUSPEND:
+                    instance.state = FopSupervisorState.SUSPENDED
+            elif isinstance(i, TransferNotification):
+                if i.notification_type == NotificationType.REJECT:
+                    logger.warning(f"FOP-1 vcid={i.gvcid.vcid}, rid={i.request_id}: FDU rejected")
+                elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
+                    logger.warning(
+                        f"FOP-1 vcid={i.gvcid.vcid}, rid={i.request_id}: FDU delivery failed"
                     )
-            for i in _drain(instance.service.interface.to_higher.pop, IndexError):
-                if isinstance(i, DirectiveNotification):
-                    if i.notification_type == NotificationType.ACCEPT:
-                        instance.requests.add(i.request_id)
-                    elif i.notification_type == NotificationType.REJECT:
-                        instance.requests.discard(i.request_id)
-                    elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
-                        if instance.state in (
-                            FopSupervisorState.RECOVERING,
-                            FopSupervisorState.INITIATING,
-                        ):
-                            instance.state = FopSupervisorState.ACTIVE
-                            instance.recovery_attempts = 0
-                        instance.requests.discard(i.request_id)
-                    elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
-                        instance.requests.discard(i.request_id)
-                elif isinstance(i, AsyncNotification):
-                    if i.notification_type == AsyncNotificationType.ALERT:
-                        self._recover(instance, i.notification_qualifier)
-                    elif i.notification_type == AsyncNotificationType.SUSPEND:
-                        instance.state = FopSupervisorState.SUSPENDED
-                elif isinstance(i, TransferNotification):
-                    if i.notification_type == NotificationType.REJECT:
-                        logger.warning(
-                            f"FOP-1 vcid={i.gvcid.vcid}, rid={i.request_id}: FDU rejected"
-                        )
-                    elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
-                        logger.warning(
-                            f"FOP-1 vcid={i.gvcid.vcid}, rid={i.request_id}: FDU delivery failed"
-                        )
 
     def _process_clcw(self) -> None:
         for clcw in _drain(self._clcw_queue.get_nowait, Empty):

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -64,7 +64,6 @@ class FopInstance:
     requests: set[int] = field(default_factory=set)
     state: FopSupervisorState = FopSupervisorState.IDLE
     _next_rid = 0
-    _last_clcw: float = 0.0
 
     def next_rid(self) -> int:
         rid = self._next_rid
@@ -174,6 +173,8 @@ class CopManagerService(Service):
                 elif isinstance(i, AsyncNotification):
                     if i.notification_type == AsyncNotificationType.ALERT:
                         self._recover(instance, i.notification_qualifier)
+                    elif i.notification_type == AsyncNotificationType.SUSPEND:
+                        instance.state = FopSupervisorState.SUSPENDED
                 elif isinstance(i, TransferNotification):
                     if i.notification_type == NotificationType.ACCEPT:
                         pass

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -35,9 +35,9 @@ from spacepackets.uslp import (
     TransferFrame,
 )
 from spacepackets.uslp.frame import FrameType
-from uslp import SPACECRAFT_ID, make_frame
 
 from ..protocols.edl_packet import EdlVcid
+from ..protocols.uslp import SPACECRAFT_ID, make_frame
 
 T = TypeVar("T")
 
@@ -167,17 +167,18 @@ class CopManagerService(Service):
                     )
                 )
                 instance.state = FopSupervisorState.INITIATING
-            for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
-                instance.service.on_receive_request_to_transfer_fdu(
-                    RequestToTransferFdu(
-                        gvcid=instance.gvcid,
-                        request_id=instance.next_rid(),
-                        fdu=fdu,
-                        service_type=ServiceType.BD
-                        if instance.state == FopSupervisorState.BD_FALLBACK
-                        else ServiceType.AD,
-                    ),
-                )
+            if instance.state in (FopSupervisorState.ACTIVE, FopSupervisorState.BD_FALLBACK):
+                for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
+                    instance.service.on_receive_request_to_transfer_fdu(
+                        RequestToTransferFdu(
+                            gvcid=instance.gvcid,
+                            request_id=instance.next_rid(),
+                            fdu=fdu,
+                            service_type=ServiceType.BD
+                            if instance.state == FopSupervisorState.BD_FALLBACK
+                            else ServiceType.AD,
+                        ),
+                    )
             for i in _drain(instance.service.interface.to_higher.pop, IndexError):
                 if isinstance(i, DirectiveNotification):
                     if i.notification_type == NotificationType.ACCEPT:
@@ -211,7 +212,12 @@ class CopManagerService(Service):
 
     def _process_clcw(self) -> None:
         for clcw in _drain(self._clcw_queue.get_nowait, Empty):
-            instance = self._fops.get(EdlVcid(clcw.vcid))
+            try:
+                vcid = EdlVcid(clcw.vcid)
+            except ValueError:
+                logger.error(f"Received CLCW with unknown VCID: {clcw.vcid}")
+                continue
+            instance = self._fops.get(vcid)
             if instance is not None:
                 if instance.state in (FopSupervisorState.IDLE, FopSupervisorState.SUSPENDED):
                     instance.service.on_receive_directive(

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from queue import Empty, SimpleQueue
 from typing import Optional
 
@@ -8,11 +9,34 @@ from ccsds_cop.cop_1.farm import (
     FduArrivedIndication,
     ValidFrameArrivedIndication,
 )
+from ccsds_cop.cop_1.fop import (
+    AbortRequest,
+    AsyncNotification,
+    AsyncNotificationType,
+    DirectiveNotification,
+    Fop1,
+    NotificationType,
+    TransferNotification,
+    TransmitRequestForFrame,
+)
 from olaf import Service, logger
-from spacepackets.uslp import TransferFrame
+from spacepackets.uslp import SourceOrDestField, TransferFrame
+from uslp import make_frame
 
 from ..protocols.edl_packet import EdlVcid
 
+
+@dataclass
+class FopInstance:
+    service: Fop1
+    recv_queue: SimpleQueue[TransferFrame] = field(default_factory=SimpleQueue)
+    requests: dict[int, bool] = field(default_factory=dict)
+    _next_rid = 0
+
+    def next_rid(self) -> int:
+        rid = self._next_rid
+        self._next_rid += 1
+        return rid
 
 class CopManagerService(Service):
     """COP-1 Services Manager
@@ -23,6 +47,7 @@ class CopManagerService(Service):
     def __init__(self) -> None:
         super().__init__()
         self._farms: dict[EdlVcid, tuple[CopService, SimpleQueue[TransferFrame]]] = {}
+        self._fops: dict[EdlVcid, FopInstance] = {}
         self.recv_queue: SimpleQueue[TransferFrame] = SimpleQueue()
 
     def on_loop(self) -> None:
@@ -57,6 +82,56 @@ class CopManagerService(Service):
                     hi.buffer_release.set()
             except IndexError:
                 continue
+
+    def _process_fop_lower(self) -> None:
+        for srv, q in self._fops.values():
+            i = srv.interface.to_lower.pop()
+            if isinstance(i, TransmitRequestForFrame):
+                fr = make_frame(
+                    payload=i.tfdf,
+                    vcid=i.gvcid.vcid,
+                    src_dest=SourceOrDestField.SOURCE,
+                    vcf_count=i.v_s,
+                )
+                q.put_nowait(fr)
+            elif isinstance(i, AbortRequest):
+                # TODO: if anything is being processed for the GVCID, abort them
+                pass
+            else:
+                logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
+
+    def _process_fop_higher(self) -> None:
+        for instance in self._fops.values():
+            try:
+                i = instance.service.interface.to_higher.pop()
+            except IndexError:
+                continue
+            if isinstance(i, DirectiveNotification):
+                if i.notification_type == NotificationType.ACCEPT:
+                    instance.requests[i.request_id] = True
+                elif i.notification_type == NotificationType.REJECT:
+                    # TODO: notify the user
+                    del instance.requests[i.request_id]
+                elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
+                    # TODO: notify user of completion
+                    del instance.requests[i.request_id]
+                elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
+                    # TODO: notify the user, note: an alert will always be received before
+                    #  NEGATIVE_CONFIRM
+                    del instance.requests[i.request_id]
+            elif isinstance(i, AsyncNotification):
+                if i.notification_type == AsyncNotificationType.ALERT:
+                    pass  # TODO: notify user
+            elif isinstance(i, TransferNotification):
+                if i.notification_type == NotificationType.ACCEPT:
+                    pass
+                elif i.notification_type == NotificationType.REJECT:
+                    pass
+                elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
+                    pass
+                elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
+                    pass
+
 
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -110,27 +110,24 @@ class CopManagerService(Service):
 
     def _process_fop_lower(self) -> None:
         for instance in self._fops.values():
-            try:
-                i = instance.service.interface.to_lower.pop()
-            except IndexError:
-                continue
-            if isinstance(i, TransmitRequestForFrame):
-                fr = make_frame(
-                    payload=i.tfdf,
-                    vcid=i.gvcid.vcid,
-                    src_dest=SourceOrDestField.SOURCE,
-                    vcf_count=i.v_s
-                    if i.bypass_flag == BypassSequenceControlFlag.SEQ_CTRLD_QOS
-                    else None,
-                    bypass=i.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS,
-                    command=i.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
-                )
-                instance.send_queue.put_nowait(fr.pack(FrameType.VARIABLE))
-            elif isinstance(i, AbortRequest):
-                # TODO: if anything is being processed for the GVCID, abort them
-                pass
-            else:
-                logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
+            for i in _drain(instance.service.interface.to_lower.pop, IndexError):
+                if isinstance(i, TransmitRequestForFrame):
+                    fr = make_frame(
+                        payload=i.tfdf,
+                        vcid=i.gvcid.vcid,
+                        src_dest=SourceOrDestField.SOURCE,
+                        vcf_count=i.v_s
+                        if i.bypass_flag == BypassSequenceControlFlag.SEQ_CTRLD_QOS
+                        else None,
+                        bypass=i.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS,
+                        command=i.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
+                    )
+                    instance.send_queue.put_nowait(fr.pack(FrameType.VARIABLE))
+                elif isinstance(i, AbortRequest):
+                    # TODO: if anything is being processed for the GVCID, abort them
+                    pass
+                else:
+                    logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
 
     def _process_fop_higher(self) -> None:
         for vcid, instance in self._fops.items():
@@ -144,35 +141,32 @@ class CopManagerService(Service):
                         service_type=ServiceType.AD,
                     ),
                 )
-            try:
-                i = instance.service.interface.to_higher.pop()
-            except IndexError:
-                continue
-            if isinstance(i, DirectiveNotification):
-                if i.notification_type == NotificationType.ACCEPT:
-                    instance.requests[i.request_id] = True
-                elif i.notification_type == NotificationType.REJECT:
-                    # TODO: notify the user
-                    del instance.requests[i.request_id]
-                elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
-                    # TODO: notify user of completion
-                    del instance.requests[i.request_id]
-                elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
-                    # TODO: notify the user, note: an alert will always be received before
-                    #  NEGATIVE_CONFIRM
-                    del instance.requests[i.request_id]
-            elif isinstance(i, AsyncNotification):
-                if i.notification_type == AsyncNotificationType.ALERT:
-                    pass  # TODO: notify user
-            elif isinstance(i, TransferNotification):
-                if i.notification_type == NotificationType.ACCEPT:
-                    pass
-                elif i.notification_type == NotificationType.REJECT:
-                    pass
-                elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
-                    pass
-                elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
-                    pass
+            for i in _drain(instance.service.interface.to_higher.pop, IndexError):
+                if isinstance(i, DirectiveNotification):
+                    if i.notification_type == NotificationType.ACCEPT:
+                        instance.requests[i.request_id] = True
+                    elif i.notification_type == NotificationType.REJECT:
+                        # TODO: notify the user
+                        del instance.requests[i.request_id]
+                    elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
+                        # TODO: notify user of completion
+                        del instance.requests[i.request_id]
+                    elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
+                        # TODO: notify the user, note: an alert will always be received before
+                        #  NEGATIVE_CONFIRM
+                        del instance.requests[i.request_id]
+                elif isinstance(i, AsyncNotification):
+                    if i.notification_type == AsyncNotificationType.ALERT:
+                        pass  # TODO: notify user
+                elif isinstance(i, TransferNotification):
+                    if i.notification_type == NotificationType.ACCEPT:
+                        pass
+                    elif i.notification_type == NotificationType.REJECT:
+                        pass
+                    elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
+                        pass
+                    elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
+                        pass
 
     def _process_clcw(self) -> None:
         for clcw in _drain(self._clcw_queue.get_nowait, Empty):

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -216,7 +216,11 @@ class CopManagerService(Service):
                 continue
             instance = self._fops.get(vcid)
             if instance is not None:
-                if instance.state in (FopSupervisorState.IDLE, FopSupervisorState.SUSPENDED):
+                if instance.state in (
+                    FopSupervisorState.IDLE,
+                    FopSupervisorState.SUSPENDED,
+                    FopSupervisorState.BD_FALLBACK,
+                ):
                     instance.service.on_receive_directive(
                         DirectiveRequest(
                             gvcid=instance.gvcid,

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -151,9 +151,9 @@ class CopManagerService(Service):
                         gvcid=Gvcid(0b1100, SPACECRAFT_ID, vcid),
                         request_id=instance.next_rid(),
                         fdu=fdu,
-                        service_type=ServiceType.AD
-                        if instance.state == FopSupervisorState.ACTIVE
-                        else ServiceType.BD,
+                        service_type=ServiceType.BD
+                        if instance.state == FopSupervisorState.BD_FALLBACK
+                        else ServiceType.AD,
                     ),
                 )
             for i in _drain(instance.service.interface.to_higher.pop, IndexError):

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -146,8 +146,8 @@ class CopManagerService(Service):
                     )
                     instance.send_queue.put_nowait(fr.pack(FrameType.VARIABLE))
                 elif isinstance(i, AbortRequest):
-                    # TODO: if anything is being processed for the GVCID, abort them
-                    pass
+                    for _ in _drain(instance.send_queue.get_nowait, Empty):
+                        pass
                 else:
                     logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
 
@@ -183,7 +183,6 @@ class CopManagerService(Service):
                     if i.notification_type == NotificationType.ACCEPT:
                         instance.requests.add(i.request_id)
                     elif i.notification_type == NotificationType.REJECT:
-                        # TODO: notify the user
                         instance.requests.discard(i.request_id)
                     elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
                         if instance.state in (
@@ -194,8 +193,6 @@ class CopManagerService(Service):
                             instance.recovery_attempts = 0
                         instance.requests.discard(i.request_id)
                     elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
-                        # TODO: notify the user, note: an alert will always be received before
-                        #  NEGATIVE_CONFIRM
                         instance.requests.discard(i.request_id)
                 elif isinstance(i, AsyncNotification):
                     if i.notification_type == AsyncNotificationType.ALERT:
@@ -203,14 +200,14 @@ class CopManagerService(Service):
                     elif i.notification_type == AsyncNotificationType.SUSPEND:
                         instance.state = FopSupervisorState.SUSPENDED
                 elif isinstance(i, TransferNotification):
-                    if i.notification_type == NotificationType.ACCEPT:
-                        pass
-                    elif i.notification_type == NotificationType.REJECT:
-                        pass
-                    elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
-                        pass
+                    if i.notification_type == NotificationType.REJECT:
+                        logger.warning(
+                            f"FOP-1 vcid={i.gvcid.vcid}, rid={i.request_id}: FDU rejected"
+                        )
                     elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
-                        pass
+                        logger.warning(
+                            f"FOP-1 vcid={i.gvcid.vcid}, rid={i.request_id}: FDU delivery failed"
+                        )
 
     def _process_clcw(self) -> None:
         for clcw in _drain(self._clcw_queue.get_nowait, Empty):

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from enum import Enum
@@ -67,6 +68,8 @@ class FopInstance:
     requests: set[int] = field(default_factory=set)
     state: FopSupervisorState = FopSupervisorState.IDLE
     last_nr: int = 0
+    recovery_attempts: int = 0
+    init_retry_at: float = 0.0
     _next_rid: int = 0
 
     def next_rid(self) -> int:
@@ -82,6 +85,7 @@ class CopManagerService(Service):
     """
 
     MAX_RECOVERY_ATTEMPTS = 3
+    INIT_RETRY_INTERVAL = 30
 
     def __init__(self) -> None:
         super().__init__()
@@ -150,6 +154,19 @@ class CopManagerService(Service):
     def _process_fop_higher(self) -> None:
         for instance in self._fops.values():
             instance.service.drain_timer_events()
+            if (
+                instance.state == FopSupervisorState.BD_FALLBACK
+                and time.monotonic() >= instance.init_retry_at
+            ):
+                instance.service.on_receive_directive(
+                    DirectiveRequest(
+                        gvcid=instance.gvcid,
+                        request_id=instance.next_rid(),
+                        directive_type=DirectiveType.INITIATE_AD_WITH_SET_V_R,
+                        directive_qualifier=instance.last_nr,
+                    )
+                )
+                instance.state = FopSupervisorState.INITIATING
             for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
                 instance.service.on_receive_request_to_transfer_fdu(
                     RequestToTransferFdu(
@@ -167,18 +184,19 @@ class CopManagerService(Service):
                         instance.requests.add(i.request_id)
                     elif i.notification_type == NotificationType.REJECT:
                         # TODO: notify the user
-                        instance.requests.remove(i.request_id)
+                        instance.requests.discard(i.request_id)
                     elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
                         if instance.state in (
                             FopSupervisorState.RECOVERING,
                             FopSupervisorState.INITIATING,
                         ):
                             instance.state = FopSupervisorState.ACTIVE
-                        instance.requests.remove(i.request_id)
+                            instance.recovery_attempts = 0
+                        instance.requests.discard(i.request_id)
                     elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
                         # TODO: notify the user, note: an alert will always be received before
                         #  NEGATIVE_CONFIRM
-                        instance.requests.remove(i.request_id)
+                        instance.requests.discard(i.request_id)
                 elif isinstance(i, AsyncNotification):
                     if i.notification_type == AsyncNotificationType.ALERT:
                         self._recover(instance, i.notification_qualifier)
@@ -214,6 +232,15 @@ class CopManagerService(Service):
                 logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")
 
     def _recover(self, instance: FopInstance, alert: Alert) -> None:
+        if alert == Alert.TERM:
+            # unrecoverable: go to IDLE
+            instance.state = FopSupervisorState.IDLE
+            return
+        instance.recovery_attempts += 1
+        if instance.recovery_attempts > self.MAX_RECOVERY_ATTEMPTS:
+            instance.state = FopSupervisorState.BD_FALLBACK
+            instance.init_retry_at = time.monotonic() + self.INIT_RETRY_INTERVAL
+            return
         instance.state = FopSupervisorState.RECOVERING
         if alert == Alert.LOCKOUT:
             instance.service.on_receive_directive(
@@ -240,9 +267,6 @@ class CopManagerService(Service):
                     directive_type=DirectiveType.INITIATE_AD_WITH_CLCW,
                 )
             )
-        elif alert == Alert.TERM:
-            # unrecoverable: go to IDLE
-            instance.state = FopSupervisorState.IDLE
 
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -49,7 +49,7 @@ def _drain(getter: Callable[[], T], exc: type[BaseException]) -> Iterator[T]:
 
 class FopSupervisorState(Enum):
     IDLE = 0
-    INTIATING = 1
+    INITIATING = 1
     ACTIVE = 2
     RECOVERING = 3
     SUSPENDED = 4
@@ -190,7 +190,7 @@ class CopManagerService(Service):
             if instance is not None:
                 if instance.state in (FopSupervisorState.IDLE, FopSupervisorState.SUSPENDED):
                     # TODO: send INITIATE_AD_WITH_SET_V_R directive
-                    instance.state = FopSupervisorState.INTIATING
+                    instance.state = FopSupervisorState.INITIATING
                 instance.service.on_clcw_arrived(clcw)
             else:
                 logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from queue import Empty, SimpleQueue
-from typing import Optional
+from typing import Optional, TypeVar
 
 from ccsds_cop.cop_1 import ControlWord, CopService, Gvcid
 from ccsds_cop.cop_1.farm import (
@@ -16,20 +17,39 @@ from ccsds_cop.cop_1.fop import (
     DirectiveNotification,
     Fop1,
     NotificationType,
+    RequestToTransferFdu,
+    ServiceType,
     TransferNotification,
     TransmitRequestForFrame,
 )
 from olaf import Service, logger
-from spacepackets.uslp import SourceOrDestField, TransferFrame
-from uslp import make_frame
+from spacepackets.uslp import (
+    BypassSequenceControlFlag,
+    ProtocolCommandFlag,
+    SourceOrDestField,
+    TransferFrame,
+)
+from spacepackets.uslp.frame import FrameType
+from uslp import SPACECRAFT_ID, make_frame
 
 from ..protocols.edl_packet import EdlVcid
+
+T = TypeVar("T")
+
+
+def _drain(getter: Callable[[], T], exc: type[BaseException]) -> Iterator[T]:
+    try:
+        while True:
+            yield getter()
+    except exc:
+        return
 
 
 @dataclass
 class FopInstance:
     service: Fop1
-    recv_queue: SimpleQueue[TransferFrame] = field(default_factory=SimpleQueue)
+    fdu_queue: SimpleQueue[bytes]
+    send_queue: SimpleQueue[bytes]
     requests: dict[int, bool] = field(default_factory=dict)
     _next_rid = 0
 
@@ -49,11 +69,15 @@ class CopManagerService(Service):
         super().__init__()
         self._farms: dict[EdlVcid, tuple[CopService, SimpleQueue[TransferFrame]]] = {}
         self._fops: dict[EdlVcid, FopInstance] = {}
+        self._clcw_queue: SimpleQueue[ControlWord] = SimpleQueue()
         self.recv_queue: SimpleQueue[TransferFrame] = SimpleQueue()
 
     def on_loop(self) -> None:
         self._process_farm_higher()
         self._process_farm_lower()
+        self._process_clcw()
+        self._process_fop_higher()
+        self._process_fop_lower()
         self.sleep_ms(50)
 
     def _process_farm_lower(self) -> None:
@@ -85,16 +109,23 @@ class CopManagerService(Service):
                 continue
 
     def _process_fop_lower(self) -> None:
-        for srv, q in self._fops.values():
-            i = srv.interface.to_lower.pop()
+        for instance in self._fops.values():
+            try:
+                i = instance.service.interface.to_lower.pop()
+            except IndexError:
+                continue
             if isinstance(i, TransmitRequestForFrame):
                 fr = make_frame(
                     payload=i.tfdf,
                     vcid=i.gvcid.vcid,
                     src_dest=SourceOrDestField.SOURCE,
-                    vcf_count=i.v_s,
+                    vcf_count=i.v_s
+                    if i.bypass_flag == BypassSequenceControlFlag.SEQ_CTRLD_QOS
+                    else None,
+                    bypass=i.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS,
+                    command=i.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
                 )
-                q.put_nowait(fr)
+                instance.send_queue.put_nowait(fr.pack(FrameType.VARIABLE))
             elif isinstance(i, AbortRequest):
                 # TODO: if anything is being processed for the GVCID, abort them
                 pass
@@ -102,7 +133,17 @@ class CopManagerService(Service):
                 logger.error(f"Unknown FOP-1 Lower Procedures request of type {type(i)}")
 
     def _process_fop_higher(self) -> None:
-        for instance in self._fops.values():
+        for vcid, instance in self._fops.items():
+            instance.service.drain_timer_events()
+            for fdu in _drain(instance.fdu_queue.get_nowait, Empty):
+                instance.service.on_receive_request_to_transfer_fdu(
+                    RequestToTransferFdu(
+                        gvcid=Gvcid(0b1100, SPACECRAFT_ID, vcid),
+                        request_id=instance.next_rid(),
+                        fdu=fdu,
+                        service_type=ServiceType.AD,
+                    ),
+                )
             try:
                 i = instance.service.interface.to_higher.pop()
             except IndexError:
@@ -133,19 +174,49 @@ class CopManagerService(Service):
                 elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
                     pass
 
+    def _process_clcw(self) -> None:
+        for clcw in _drain(self._clcw_queue.get_nowait, Empty):
+            instance = self._fops.get(EdlVcid(clcw.vcid))
+            if instance is not None:
+                instance.service.on_clcw_arrived(clcw)
+            else:
+                logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")
+
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")
         q: SimpleQueue[TransferFrame] = SimpleQueue()
         self._farms[vcid] = (Farm1(w=20, vcf_count_length=1), q)
         return q
 
+    def create_fop_service(
+        self, vcid: EdlVcid, send_queue: SimpleQueue[bytes]
+    ) -> SimpleQueue[bytes]:
+        """Create a FOP-1 Service for a VCID.
+
+        Parameters
+        ----------
+        vcid
+            The VCID to assoociate with the FOP-1 Service.
+        send_queue
+            The queue into which FOP-1 will place frames assembled by the Lower Procedures.
+
+        Returns
+        -------
+        SimpleQueue[bytes]
+            A queue of FDUs for FOP-1.
+        """
+        logger.info(f"Creating FOP-1 Service for VCID {vcid}")
+        q: SimpleQueue[bytes] = SimpleQueue()
+        self._fops[vcid] = FopInstance(
+            service=Fop1(Gvcid(0b1100, SPACECRAFT_ID, vcid)),
+            fdu_queue=q,
+            send_queue=send_queue,
+        )
+        return q
+
     def dispatch_clcw(self, clcw: ControlWord) -> None:
         """Hand a control word to the COP Manager for automatic routing to a FOP-1 instance."""
-        instance = self._fops.get(clcw.vcid)
-        if instance is not None:
-            instance.service.on_clcw_arrived(clcw)
-        else:
-            logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")
+        self._clcw_queue.put_nowait(clcw)
 
     def get_service(self, vcid: EdlVcid) -> Optional[CopService]:
         entry = self._farms.get(vcid)

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
+from enum import Enum
 from queue import Empty, SimpleQueue
 from typing import Optional, TypeVar
 
@@ -12,6 +13,7 @@ from ccsds_cop.cop_1.farm import (
 )
 from ccsds_cop.cop_1.fop import (
     AbortRequest,
+    Alert,
     AsyncNotification,
     AsyncNotificationType,
     DirectiveNotification,
@@ -45,13 +47,24 @@ def _drain(getter: Callable[[], T], exc: type[BaseException]) -> Iterator[T]:
         return
 
 
+class FopSupervisorState(Enum):
+    IDLE = 0
+    INTIATING = 1
+    ACTIVE = 2
+    RECOVERING = 3
+    SUSPENDED = 4
+    BD_FALLBACK = 5
+
+
 @dataclass
 class FopInstance:
     service: Fop1
     fdu_queue: SimpleQueue[bytes]
     send_queue: SimpleQueue[bytes]
     requests: dict[int, bool] = field(default_factory=dict)
+    state: FopSupervisorState = FopSupervisorState.IDLE
     _next_rid = 0
+    _last_clcw: float = 0.0
 
     def next_rid(self) -> int:
         rid = self._next_rid
@@ -138,7 +151,9 @@ class CopManagerService(Service):
                         gvcid=Gvcid(0b1100, SPACECRAFT_ID, vcid),
                         request_id=instance.next_rid(),
                         fdu=fdu,
-                        service_type=ServiceType.AD,
+                        service_type=ServiceType.AD
+                        if instance.state == FopSupervisorState.ACTIVE
+                        else ServiceType.BD,
                     ),
                 )
             for i in _drain(instance.service.interface.to_higher.pop, IndexError):
@@ -149,7 +164,8 @@ class CopManagerService(Service):
                         # TODO: notify the user
                         del instance.requests[i.request_id]
                     elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
-                        # TODO: notify user of completion
+                        if instance.state == FopSupervisorState.RECOVERING:
+                            instance.state = FopSupervisorState.ACTIVE
                         del instance.requests[i.request_id]
                     elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
                         # TODO: notify the user, note: an alert will always be received before
@@ -157,7 +173,7 @@ class CopManagerService(Service):
                         del instance.requests[i.request_id]
                 elif isinstance(i, AsyncNotification):
                     if i.notification_type == AsyncNotificationType.ALERT:
-                        pass  # TODO: notify user
+                        self._recover(instance, i.notification_qualifier)
                 elif isinstance(i, TransferNotification):
                     if i.notification_type == NotificationType.ACCEPT:
                         pass
@@ -172,9 +188,24 @@ class CopManagerService(Service):
         for clcw in _drain(self._clcw_queue.get_nowait, Empty):
             instance = self._fops.get(EdlVcid(clcw.vcid))
             if instance is not None:
+                if instance.state in (FopSupervisorState.IDLE, FopSupervisorState.SUSPENDED):
+                    # TODO: send INITIATE_AD_WITH_SET_V_R directive
+                    instance.state = FopSupervisorState.INTIATING
                 instance.service.on_clcw_arrived(clcw)
             else:
                 logger.error(f"Received invalid VCID in CLCW: {clcw.vcid}")
+
+    def _recover(self, instance: FopInstance, alert: Alert) -> None:
+        instance.state = FopSupervisorState.RECOVERING
+        if alert == Alert.LOCKOUT:
+            pass  # init ad with unlock
+        elif alert in (Alert.SYNCH, Alert.NNR, Alert.CLCW):
+            pass  # init ad with set vr (from last CLCW)
+        elif alert in (Alert.LIMIT, Alert.T1, Alert.LLIF):
+            pass  # init with clcw
+        elif alert == Alert.TERM:
+            # unrecoverable: go to IDLE
+            instance.state = FopSupervisorState.IDLE
 
     def create_farm_service(self, vcid: EdlVcid) -> SimpleQueue[TransferFrame]:
         logger.info(f"Creating FARM-1 Service for VCID {vcid}")

--- a/oresat_c3/services/cop_manager.py
+++ b/oresat_c3/services/cop_manager.py
@@ -61,7 +61,7 @@ class FopInstance:
     service: Fop1
     fdu_queue: SimpleQueue[bytes]
     send_queue: SimpleQueue[bytes]
-    requests: dict[int, bool] = field(default_factory=dict)
+    requests: set[int] = field(default_factory=set)
     state: FopSupervisorState = FopSupervisorState.IDLE
     _next_rid = 0
     _last_clcw: float = 0.0
@@ -159,18 +159,18 @@ class CopManagerService(Service):
             for i in _drain(instance.service.interface.to_higher.pop, IndexError):
                 if isinstance(i, DirectiveNotification):
                     if i.notification_type == NotificationType.ACCEPT:
-                        instance.requests[i.request_id] = True
+                        instance.requests.add(i.request_id)
                     elif i.notification_type == NotificationType.REJECT:
                         # TODO: notify the user
-                        del instance.requests[i.request_id]
+                        instance.requests.remove(i.request_id)
                     elif i.notification_type == NotificationType.POSITIVE_CONFIRM:
                         if instance.state == FopSupervisorState.RECOVERING:
                             instance.state = FopSupervisorState.ACTIVE
-                        del instance.requests[i.request_id]
+                        instance.requests.remove(i.request_id)
                     elif i.notification_type == NotificationType.NEGATIVE_CONFIRM:
                         # TODO: notify the user, note: an alert will always be received before
                         #  NEGATIVE_CONFIRM
-                        del instance.requests[i.request_id]
+                        instance.requests.remove(i.request_id)
                 elif isinstance(i, AsyncNotification):
                     if i.notification_type == AsyncNotificationType.ALERT:
                         self._recover(instance, i.notification_qualifier)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "skyfield>=1.54",
     "smbus2",
     "spacepackets>=0.30.1",
-    "ccsds-cop>=0.0.0",
+    "ccsds-cop>=0.1.1",
     "typing-extensions>=4.13.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "skyfield>=1.54",
     "smbus2",
     "spacepackets>=0.30.1",
-    "ccsds-cop>=0.1.1",
+    "ccsds-cop>=0.1.2",
     "typing-extensions>=4.13.0"
 ]
 

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -265,11 +265,11 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.RESUME_AD)
         )
-        while True:
-            try:
+        try:
+            while True:
                 self._fop1.interface.to_higher.pop()
-            except IndexError:
-                break
+        except IndexError:
+            pass
         print(f"FOP-1 resumed: state={self._fop1.state.name}, V(S)={self._fop1.v_s}")
 
     def help_cop_init(self):
@@ -288,11 +288,11 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
         )
-        while True:
-            try:
+        try:
+            while True:
                 self._fop1.interface.to_higher.pop()
-            except IndexError:
-                break
+        except IndexError:
+            pass
 
         if arg.strip():
             v_r = int(arg.strip(), 0)
@@ -317,11 +317,11 @@ class EdlCommandShell(Cmd):
                         target_v_s,
                     )
                 )
-                while True:
-                    try:
+                try:
+                    while True:
                         self._fop1.interface.to_higher.pop()
-                    except IndexError:
-                        break
+                except IndexError:
+                    pass
             directive = DirectiveRequest(
                 self._gvcid, self._fop1_req_id, DirectiveType.INITIATE_AD_WITH_CLCW
             )
@@ -365,7 +365,8 @@ class EdlCommandShell(Cmd):
                 if isinstance(notif, DirectiveNotification):
                     if notif.notification_type == NotificationType.POSITIVE_CONFIRM:
                         print(
-                            f"FOP-1 initialized: state={self._fop1.state.name}, V(S)={self._fop1.v_s}"
+                            f"FOP-1 initialized: state={self._fop1.state.name},"
+                            f" V(S)={self._fop1.v_s}"
                         )
                     else:
                         print(

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -31,12 +31,12 @@ from spacepackets.uslp import BypassSequenceControlFlag, ProtocolCommandFlag
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
 from spacepackets.uslp.frame import FrameType
 
-from oresat_c3.protocols.uslp import SEQ_NUM_LEN, SPACECRAFT_ID, make_frame, unpack_frame
+from oresat_c3.protocols.uslp import SPACECRAFT_ID, make_frame, unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EDL_COMMANDS, EdlCommandCode, EdlCommandRequest
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid, gen_hmac
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
 
 
 class EdlCommandShell(Cmd):
@@ -73,7 +73,6 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, 0, DirectiveType.INITIATE_AD_NO_CLCW)
         )
-        # Signal lower layer ready so FOP-1 can transmit the first frame
         self._fop1.on_receive_response_from_lower_layer(
             Response(self._gvcid, ResponseType.AD_ACCEPTED)
         )
@@ -93,7 +92,8 @@ class EdlCommandShell(Cmd):
                     payload=req.tfdf,
                     vcid=EdlVcid.C3_COMMAND,
                     src_dest=SRC_DEST_ORESAT,
-                    insert_zone=self._seq_num.to_bytes(SEQ_NUM_LEN, "little"),
+                    hmac_key=self._hmac_key,
+                    sequence_number=self._seq_num,
                     vcf_count=None if bypass else req.v_s,
                     bypass=bypass,
                     command=req.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
@@ -149,8 +149,7 @@ class EdlCommandShell(Cmd):
 
         res_packet = None
         try:
-            payload_raw = EdlCommandRequest(code, args).pack()
-            tfdz = payload_raw + gen_hmac(self._hmac_key, payload_raw)
+            tfdz = EdlCommandRequest(code, args).pack()
 
             self._fop1_req_id += 1
             self._fop1.on_receive_request_to_transfer_fdu(
@@ -195,7 +194,7 @@ class EdlCommandShell(Cmd):
                     finally:
                         self._downlink_socket.settimeout(self._timeout)
             else:
-                # No EDL response expected, but still wait for a CLCW to acknowledge the AD frame
+                # no EDL response expected, but still wait for a CLCW to acknowledge the AD frame
                 for _ in range(10):
                     try:
                         raw = self._downlink_socket.recv(1024)
@@ -210,7 +209,6 @@ class EdlCommandShell(Cmd):
                         if self._fop1.nn_r == self._fop1.v_s:
                             break
 
-            # Lower layer ready for next frame
             self._fop1.on_receive_response_from_lower_layer(
                 Response(self._gvcid, ResponseType.AD_ACCEPTED)
             )
@@ -286,7 +284,6 @@ class EdlCommandShell(Cmd):
         if self._fop1.suspend_state != 0:
             print("FOP-1 is suspended; use 'cop_resume' before reinitializing")
             return
-        # Always terminate first — no-op from INITIAL, resets cleanly from any other state
         self._fop1_req_id += 1
         self._fop1.on_receive_directive(
             DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
@@ -299,7 +296,7 @@ class EdlCommandShell(Cmd):
 
         if arg.strip():
             v_r = int(arg.strip(), 0)
-            # Bootstrap bc_out=True so FOP-1 can send the BC frame
+            # force bc_out=True so FOP-1 can send the BC frame
             self._fop1.on_receive_response_from_lower_layer(
                 Response(self._gvcid, ResponseType.BC_ACCEPTED)
             )
@@ -311,7 +308,6 @@ class EdlCommandShell(Cmd):
             last = self._last_clcw.get(self._gvcid.vcid)
             target_v_s = last.report_value if last is not None else self._fop1.v_s
             if target_v_s != self._fop1.v_s or self._fop1.nn_r != self._fop1.v_s:
-                # Align V(S) to FARM-1's V(R) without touching FARM-1
                 self._fop1_req_id += 1
                 self._fop1.on_receive_directive(
                     DirectiveRequest(
@@ -333,7 +329,6 @@ class EdlCommandShell(Cmd):
         self._fop1.on_receive_directive(directive)
         self._flush_fop_lower()
 
-        # Consume the immediate ACCEPT (or REJECT) from the directive
         while True:
             try:
                 notif = self._fop1.interface.to_higher.pop()
@@ -343,9 +338,7 @@ class EdlCommandShell(Cmd):
                 if notif.notification_type == NotificationType.REJECT:
                     print(f"FOP-1 init rejected (state={self._fop1.state.name})")
                     return
-                # ACCEPT: proceed to wait for CLCW confirmation
 
-        # Wait for CLCW to trigger POSITIVE_CONFIRM (or NEGATIVE_CONFIRM on alert)
         for _ in range(10):
             try:
                 raw = self._downlink_socket.recv(1024)
@@ -518,15 +511,16 @@ class EdlCommandShell(Cmd):
         if not respone:
             return
 
-        if respone[0] != 0:
-            print(f"SDO error code: 0x{respone[0]:08X}")
+        # response tuple: (node_id, index, subindex, ecode, len_data, data)
+        if respone[3] != 0:
+            print(f"SDO error code: 0x{respone[3]:08X}")
             return
 
         if isinstance(od[index], canopen.objectdictionary.Variable):
             obj = od[index]
         else:
             obj = od[index][subindex]
-        value = obj.decode_raw(respone[2])
+        value = obj.decode_raw(respone[5])
         print("Value from SDO read: ", value)
 
     def help_sdo_write(self):

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -109,7 +109,6 @@ class EdlCommandShell(Cmd):
         if clcw.vcid == self._gvcid.vcid:
             self._fop1.on_clcw_arrived(clcw)
             self._flush_fop_lower()
-            # Drain alerts from interface.to_higher
             while True:
                 try:
                     notif = self._fop1.interface.to_higher.pop()
@@ -142,20 +141,39 @@ class EdlCommandShell(Cmd):
             self._downlink_socket.settimeout(self._timeout)
 
     def _send_packet(self, code: EdlCommandCode, args: Union[tuple, None] = None) -> tuple:
-        print(f"Request {code.name}: {args} | seq_num: {self._seq_num}")
         # processing cop sequentially is unusual, so we need to drain any CLCWs
         # from the previous command before the next frame to prevent timeouts
         self._drain_clcws()
+
+        sequenced = self._fop1.state == FopState.ACTIVE
+        print(
+            f"Request {code.name}: {args} | seq_num: {self._seq_num}"
+            f" | {'sequenced' if sequenced else 'expedited'}"
+        )
 
         res_packet = None
         try:
             tfdz = EdlCommandRequest(code, args).pack()
 
-            self._fop1_req_id += 1
-            self._fop1.on_receive_request_to_transfer_fdu(
-                RequestToTransferFdu(self._gvcid, self._fop1_req_id, tfdz, ServiceType.AD)
-            )
-            self._flush_fop_lower()
+            if sequenced:
+                self._fop1_req_id += 1
+                self._fop1.on_receive_request_to_transfer_fdu(
+                    RequestToTransferFdu(self._gvcid, self._fop1_req_id, tfdz, ServiceType.AD)
+                )
+                self._flush_fop_lower()
+            else:
+                frame = make_frame(
+                    payload=tfdz,
+                    vcid=EdlVcid.C3_COMMAND,
+                    src_dest=SRC_DEST_ORESAT,
+                    hmac_key=self._hmac_key,
+                    sequence_number=self._seq_num,
+                    bypass=True,
+                )
+                self._uplink_socket.sendto(
+                    frame.pack(frame_type=FrameType.VARIABLE),
+                    self._uplink_address,
+                )
 
             edl_command = EDL_COMMANDS[code]
             if edl_command.res_fmt is not None or edl_command.res_unpack_func is not None:
@@ -174,7 +192,7 @@ class EdlCommandShell(Cmd):
                             break
                 except socket.timeout:
                     raise TimeoutError("No C3_COMMAND response")
-                if self._fop1.nn_r != self._fop1.v_s:
+                if sequenced and self._fop1.nn_r != self._fop1.v_s:
                     self._downlink_socket.settimeout(self._fop1.timer_initial_value)
                     try:
                         while (
@@ -193,8 +211,8 @@ class EdlCommandShell(Cmd):
                                 self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
                     finally:
                         self._downlink_socket.settimeout(self._timeout)
-            else:
-                # no EDL response expected, but still wait for a CLCW to acknowledge the AD frame
+            elif sequenced:
+                # no EDL response expected, wait for CLCW to acknowledge the AD frame
                 for _ in range(10):
                     try:
                         raw = self._downlink_socket.recv(1024)
@@ -209,9 +227,10 @@ class EdlCommandShell(Cmd):
                         if self._fop1.nn_r == self._fop1.v_s:
                             break
 
-            self._fop1.on_receive_response_from_lower_layer(
-                Response(self._gvcid, ResponseType.AD_ACCEPTED)
-            )
+            if sequenced:
+                self._fop1.on_receive_response_from_lower_layer(
+                    Response(self._gvcid, ResponseType.AD_ACCEPTED)
+                )
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718
             print(e)
@@ -271,6 +290,24 @@ class EdlCommandShell(Cmd):
         except IndexError:
             pass
         print(f"FOP-1 resumed: state={self._fop1.state.name}, V(S)={self._fop1.v_s}")
+
+    def help_cop_terminate(self):
+        """Print help message for cop_terminate command."""
+        print("cop_terminate")
+        print("  terminate FOP-1 AD service. Subsequent commands are sent expedited")
+
+    def do_cop_terminate(self, _):
+        """Terminate FOP-1 AD service."""
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
+        )
+        try:
+            while True:
+                self._fop1.interface.to_higher.pop()
+        except IndexError:
+            pass
+        print(f"FOP-1 terminated: state={self._fop1.state.name}")
 
     def help_cop_init(self):
         """Print help message for cop_init command."""

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -18,6 +18,7 @@ from ccsds_cop.cop_1.fop import (
     DirectiveRequest,
     DirectiveType,
     Fop1,
+    FopState,
     NotificationType,
     RequestToTransferFdu,
     Response,
@@ -30,7 +31,7 @@ from spacepackets.uslp import BypassSequenceControlFlag, ProtocolCommandFlag
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
 from spacepackets.uslp.frame import FrameType
 
-from oresat_c3.protocols.uslp import SPACECRAFT_ID, SEQ_NUM_LEN, make_frame, unpack_frame
+from oresat_c3.protocols.uslp import SEQ_NUM_LEN, SPACECRAFT_ID, make_frame, unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -142,6 +143,9 @@ class EdlCommandShell(Cmd):
 
     def _send_packet(self, code: EdlCommandCode, args: Union[tuple, None] = None) -> tuple:
         print(f"Request {code.name}: {args} | seq_num: {self._seq_num}")
+        # processing cop sequentially is unusual, so we need to drain any CLCWs
+        # from the previous command before the next frame to prevent timeouts
+        self._drain_clcws()
 
         res_packet = None
         try:
@@ -171,6 +175,25 @@ class EdlCommandShell(Cmd):
                             break
                 except socket.timeout:
                     raise TimeoutError("No C3_COMMAND response")
+                if self._fop1.nn_r != self._fop1.v_s:
+                    self._downlink_socket.settimeout(self._fop1.timer_initial_value)
+                    try:
+                        while (
+                            self._fop1.nn_r != self._fop1.v_s
+                            and self._fop1.state == FopState.ACTIVE
+                        ):
+                            try:
+                                raw = self._downlink_socket.recv(1024)
+                            except socket.timeout:
+                                break
+                            try:
+                                frame = unpack_frame(raw)
+                            except UslpInvalidRawPacketOrFrameLenError:
+                                continue
+                            if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                                self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+                    finally:
+                        self._downlink_socket.settimeout(self._timeout)
             else:
                 # No EDL response expected, but still wait for a CLCW to acknowledge the AD frame
                 for _ in range(10):

--- a/scripts/edl_cmd_shell.py
+++ b/scripts/edl_cmd_shell.py
@@ -10,15 +10,32 @@ from time import time
 from typing import Any, Union
 
 import canopen
+from ccsds_cop.cop_1 import ControlWord, Gvcid
+from ccsds_cop.cop_1.fop import (
+    AsyncNotification,
+    AsyncNotificationType,
+    DirectiveNotification,
+    DirectiveRequest,
+    DirectiveType,
+    Fop1,
+    NotificationType,
+    RequestToTransferFdu,
+    Response,
+    ResponseType,
+    ServiceType,
+    TransmitRequestForFrame,
+)
 from oresat_configs import Mission, OreSatConfig
+from spacepackets.uslp import BypassSequenceControlFlag, ProtocolCommandFlag
 from spacepackets.uslp.defs import UslpInvalidRawPacketOrFrameLenError
+from spacepackets.uslp.frame import FrameType
 
-from oresat_c3.protocols.uslp import unpack_frame
+from oresat_c3.protocols.uslp import SPACECRAFT_ID, SEQ_NUM_LEN, make_frame, unpack_frame
 
 sys.path.insert(0, os.path.abspath(".."))
 
 from oresat_c3.protocols.edl_command import EDL_COMMANDS, EdlCommandCode, EdlCommandRequest
-from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlPacket, EdlVcid, gen_hmac
 
 
 class EdlCommandShell(Cmd):
@@ -48,32 +65,132 @@ class EdlCommandShell(Cmd):
         self._downlink_socket.bind(self._downlink_address)
         self._downlink_socket.settimeout(self._timeout)
 
+        self._gvcid = Gvcid(tfvn=0xC, scid=SPACECRAFT_ID, vcid=EdlVcid.C3_COMMAND)
+        self._fop1 = Fop1(self._gvcid, timer_initial_value=3)
+        self._fop1_req_id = 0
+        self._last_clcw: dict[int, ControlWord] = {}
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, 0, DirectiveType.INITIATE_AD_NO_CLCW)
+        )
+        # Signal lower layer ready so FOP-1 can transmit the first frame
+        self._fop1.on_receive_response_from_lower_layer(
+            Response(self._gvcid, ResponseType.AD_ACCEPTED)
+        )
+
+    def _flush_fop_lower(self) -> None:
+        """Send any frames queued by FOP-1 to the uplink socket."""
+        for queue in (self._fop1.interface.to_lower, self._fop1.lower_interface.signal):
+            while True:
+                try:
+                    req = queue.pop()
+                except IndexError:
+                    break
+                if not isinstance(req, TransmitRequestForFrame):
+                    continue
+                bypass = req.bypass_flag == BypassSequenceControlFlag.EXPEDITED_QOS
+                frame = make_frame(
+                    payload=req.tfdf,
+                    vcid=EdlVcid.C3_COMMAND,
+                    src_dest=SRC_DEST_ORESAT,
+                    insert_zone=self._seq_num.to_bytes(SEQ_NUM_LEN, "little"),
+                    vcf_count=None if bypass else req.v_s,
+                    bypass=bypass,
+                    command=req.command_flag == ProtocolCommandFlag.PROTOCOL_INFORMATION,
+                )
+                self._uplink_socket.sendto(
+                    frame.pack(frame_type=FrameType.VARIABLE),
+                    self._uplink_address,
+                )
+
+    def _process_clcw(self, clcw: ControlWord) -> None:
+        """Feed a CLCW to FOP-1 and warn if the state machine falls back to INITIAL."""
+        self._last_clcw[clcw.vcid] = clcw
+        if clcw.vcid == self._gvcid.vcid:
+            self._fop1.on_clcw_arrived(clcw)
+            self._flush_fop_lower()
+            # Drain alerts from interface.to_higher
+            while True:
+                try:
+                    notif = self._fop1.interface.to_higher.pop()
+                except IndexError:
+                    break
+                if (
+                    isinstance(notif, AsyncNotification)
+                    and notif.notification_type == AsyncNotificationType.ALERT
+                ):
+                    print(
+                        f"FOP-1 alert: {notif.notification_qualifier.name} "
+                        f"(state={self._fop1.state.name}, use 'cop_init' to reinitialize)"
+                    )
+
+    def _drain_clcws(self) -> None:
+        """Drain any buffered CLCW frames from the socket without blocking."""
+        self._downlink_socket.settimeout(0)
+        try:
+            while True:
+                raw = self._downlink_socket.recv(1024)
+                try:
+                    frame = unpack_frame(raw)
+                except UslpInvalidRawPacketOrFrameLenError:
+                    continue
+                if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                    self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+        except (socket.timeout, BlockingIOError):
+            pass
+        finally:
+            self._downlink_socket.settimeout(self._timeout)
+
     def _send_packet(self, code: EdlCommandCode, args: Union[tuple, None] = None) -> tuple:
         print(f"Request {code.name}: {args} | seq_num: {self._seq_num}")
 
         res_packet = None
         try:
-            # make packet
-            req = EdlCommandRequest(code, args)
-            req_packet = EdlPacket(req, self._seq_num, SRC_DEST_ORESAT, bypass=True)
-            req_packet_raw = req_packet.pack(self._hmac_key)
+            payload_raw = EdlCommandRequest(code, args).pack()
+            tfdz = payload_raw + gen_hmac(self._hmac_key, payload_raw)
 
-            # send request
-            self._uplink_socket.sendto(req_packet_raw, self._uplink_address)
+            self._fop1_req_id += 1
+            self._fop1.on_receive_request_to_transfer_fdu(
+                RequestToTransferFdu(self._gvcid, self._fop1_req_id, tfdz, ServiceType.AD)
+            )
+            self._flush_fop_lower()
 
             edl_command = EDL_COMMANDS[code]
             if edl_command.res_fmt is not None or edl_command.res_unpack_func is not None:
+                try:
+                    while True:
+                        raw = self._downlink_socket.recv(1024)
+                        try:
+                            frame = unpack_frame(raw)
+                        except UslpInvalidRawPacketOrFrameLenError:
+                            continue
+                        if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                            self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+                            continue
+                        if frame.header.vcid == EdlVcid.C3_COMMAND:
+                            res_packet = EdlPacket.from_frame(frame, self._hmac_key)
+                            break
+                except socket.timeout:
+                    raise TimeoutError("No C3_COMMAND response")
+            else:
+                # No EDL response expected, but still wait for a CLCW to acknowledge the AD frame
                 for _ in range(10):
-                    res_packet_raw = self._downlink_socket.recv(1024)
                     try:
-                        frame = unpack_frame(res_packet_raw)
+                        raw = self._downlink_socket.recv(1024)
+                    except socket.timeout:
+                        break
+                    try:
+                        frame = unpack_frame(raw)
                     except UslpInvalidRawPacketOrFrameLenError:
                         continue
-                    if frame.header.vcid == EdlVcid.C3_COMMAND:
-                        break
-                else:
-                    raise TimeoutError("No C3_COMMAND response received after 10 attempts")
-                res_packet = EdlPacket.from_frame(frame, self._hmac_key)
+                    if frame.header.vcid == EdlVcid.IDLE and frame.op_ctrl_field:
+                        self._process_clcw(ControlWord.unpack(frame.op_ctrl_field))
+                        if self._fop1.nn_r == self._fop1.v_s:
+                            break
+
+            # Lower layer ready for next frame
+            self._fop1.on_receive_response_from_lower_layer(
+                Response(self._gvcid, ResponseType.AD_ACCEPTED)
+            )
             self._seq_num += 1
         except Exception as e:  # pylint: disable=W0718
             print(e)
@@ -85,6 +202,171 @@ class EdlCommandShell(Cmd):
             print(f"Response {code.name}: {ret}")
 
         return ret
+
+    def help_cop_status(self):
+        """Print help message for cop_status command."""
+        print("cop_status")
+        print("  print FOP-1 state and last known CLCWs")
+
+    def do_cop_status(self, _):
+        """Print FOP-1 state and last known CLCWs."""
+        self._drain_clcws()
+        fop = self._fop1
+        print(f"FOP-1 state : {fop.state.name}")
+        print(f"  V(S)      = {fop.v_s}")
+        print(f"  NN(R)     = {fop.nn_r}")
+        print(f"  ad_out    = {fop.ad_out}")
+        print(f"  sent queue= {len(fop._sent_queue)}")  # pylint: disable=W0212
+        if self._last_clcw:
+            print("Last CLCWs:")
+            for vcid, clcw in sorted(self._last_clcw.items()):
+                print(
+                    f"  VCID {vcid}: V(R)={clcw.report_value}"
+                    f"  lockout={clcw.lockout}"
+                    f"  wait={clcw.wait}"
+                    f"  retransmit={clcw.retransmit}"
+                    f"  farm_b={clcw.farm_b_counter}"
+                )
+        else:
+            print("No CLCWs received yet")
+
+    def help_cop_resume(self):
+        """Print help message for cop_resume command."""
+        print("cop_resume")
+        print("  resume a suspended FOP-1 AD service")
+
+    def do_cop_resume(self, _):
+        """Resume a suspended FOP-1 AD service."""
+        if self._fop1.suspend_state == 0:
+            print("FOP-1 is not suspended")
+            return
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.RESUME_AD)
+        )
+        while True:
+            try:
+                self._fop1.interface.to_higher.pop()
+            except IndexError:
+                break
+        print(f"FOP-1 resumed: state={self._fop1.state.name}, V(S)={self._fop1.v_s}")
+
+    def help_cop_init(self):
+        """Print help message for cop_init command."""
+        print("cop_init [v_r]")
+        print("  reinitialize FOP-1 AD mode, waiting for CLCW confirmation")
+        print("  no args: INITIATE_AD_WITH_CLCW — if V(S)!=V(R), SET_V_S first, then sync")
+        print("  <v_r>:   INITIATE_AD_WITH_SET_V_R — send BC frame to set FARM-1 V(R) to <v_r>")
+
+    def do_cop_init(self, arg: str):
+        """Reinitialize FOP-1 AD mode, blocking until CLCW confirms ACTIVE."""
+        if self._fop1.suspend_state != 0:
+            print("FOP-1 is suspended; use 'cop_resume' before reinitializing")
+            return
+        # Always terminate first — no-op from INITIAL, resets cleanly from any other state
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(
+            DirectiveRequest(self._gvcid, self._fop1_req_id, DirectiveType.TERMINATE_AD)
+        )
+        while True:
+            try:
+                self._fop1.interface.to_higher.pop()
+            except IndexError:
+                break
+
+        if arg.strip():
+            v_r = int(arg.strip(), 0)
+            # Bootstrap bc_out=True so FOP-1 can send the BC frame
+            self._fop1.on_receive_response_from_lower_layer(
+                Response(self._gvcid, ResponseType.BC_ACCEPTED)
+            )
+            directive = DirectiveRequest(
+                self._gvcid, self._fop1_req_id, DirectiveType.INITIATE_AD_WITH_SET_V_R, v_r
+            )
+        else:
+            self._drain_clcws()
+            last = self._last_clcw.get(self._gvcid.vcid)
+            target_v_s = last.report_value if last is not None else self._fop1.v_s
+            if target_v_s != self._fop1.v_s or self._fop1.nn_r != self._fop1.v_s:
+                # Align V(S) to FARM-1's V(R) without touching FARM-1
+                self._fop1_req_id += 1
+                self._fop1.on_receive_directive(
+                    DirectiveRequest(
+                        self._gvcid,
+                        self._fop1_req_id,
+                        DirectiveType.SET_V_S,
+                        target_v_s,
+                    )
+                )
+                while True:
+                    try:
+                        self._fop1.interface.to_higher.pop()
+                    except IndexError:
+                        break
+            directive = DirectiveRequest(
+                self._gvcid, self._fop1_req_id, DirectiveType.INITIATE_AD_WITH_CLCW
+            )
+        self._fop1_req_id += 1
+        self._fop1.on_receive_directive(directive)
+        self._flush_fop_lower()
+
+        # Consume the immediate ACCEPT (or REJECT) from the directive
+        while True:
+            try:
+                notif = self._fop1.interface.to_higher.pop()
+            except IndexError:
+                break
+            if isinstance(notif, DirectiveNotification):
+                if notif.notification_type == NotificationType.REJECT:
+                    print(f"FOP-1 init rejected (state={self._fop1.state.name})")
+                    return
+                # ACCEPT: proceed to wait for CLCW confirmation
+
+        # Wait for CLCW to trigger POSITIVE_CONFIRM (or NEGATIVE_CONFIRM on alert)
+        for _ in range(10):
+            try:
+                raw = self._downlink_socket.recv(1024)
+            except socket.timeout:
+                print("Timeout: no CLCW confirmation received")
+                return
+            try:
+                frame = unpack_frame(raw)
+            except UslpInvalidRawPacketOrFrameLenError:
+                continue
+            if frame.header.vcid != EdlVcid.IDLE or not frame.op_ctrl_field:
+                continue
+            clcw = ControlWord.unpack(frame.op_ctrl_field)
+            self._last_clcw[clcw.vcid] = clcw
+            if clcw.vcid != self._gvcid.vcid:
+                continue
+            self._fop1.on_clcw_arrived(clcw)
+            self._flush_fop_lower()
+            while True:
+                try:
+                    notif = self._fop1.interface.to_higher.pop()
+                except IndexError:
+                    break
+                if isinstance(notif, DirectiveNotification):
+                    if notif.notification_type == NotificationType.POSITIVE_CONFIRM:
+                        print(
+                            f"FOP-1 initialized: state={self._fop1.state.name}, V(S)={self._fop1.v_s}"
+                        )
+                    else:
+                        print(
+                            f"FOP-1 init failed (state={self._fop1.state.name}, "
+                            "use 'cop_init' to retry)"
+                        )
+                    return
+                if (
+                    isinstance(notif, AsyncNotification)
+                    and notif.notification_type == AsyncNotificationType.ALERT
+                ):
+                    print(
+                        f"FOP-1 alert: {notif.notification_qualifier.name} "
+                        f"(state={self._fop1.state.name}, use 'cop_init' to retry)"
+                    )
+                    return
+        print("No CLCW confirmation received")
 
     def help_tx_control(self):
         """Print help message for tx control command."""

--- a/tests/protocols/test_uslp.py
+++ b/tests/protocols/test_uslp.py
@@ -6,7 +6,6 @@ from spacepackets.uslp.defs import UslpChecksumError, UslpInvalidRawPacketOrFram
 from spacepackets.uslp.frame import FrameType
 
 from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlVcid
-from oresat_c3.protocols.sdls import verify_sdls
 from oresat_c3.protocols.uslp import make_frame, unpack_frame
 
 HMAC_KEY = b"\x00" * 32
@@ -32,9 +31,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         unpacked = unpack_frame(raw)
         self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
         self.assertIsNotNone(unpacked.insert_zone)
-        seq = verify_sdls(unpacked, HMAC_KEY)
-        self.assertEqual(seq, 5)
-        self.assertEqual(unpacked.tfdf.tfdz, b"\x01\x02\x03")
+        self.assertTrue(unpacked.tfdf.tfdz.startswith(b"\x01\x02\x03"))
 
     def test_ad_frame_len_is_total_minus_one(self):
         """frame_len header field must equal total packed bytes minus one."""
@@ -76,7 +73,7 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
         self.assertEqual(unpacked.tfdf.tfdz, b"\x00")
 
     def test_bc_frame_no_sdls(self):
-        """SDLS must not be applied to bypass frames."""
+        """Type-BC (command) frames must not have an SDLS insert zone."""
         frame = make_frame(
             b"\x00",
             EdlVcid.C3_COMMAND,
@@ -85,6 +82,35 @@ class TestMakeFrameUnpackFrame(unittest.TestCase):
             command=True,
         )
         self.assertIsNone(frame.insert_zone)
+
+    def test_bd_frame_has_sdls(self):
+        """Type-BD frames must have an SDLS insert zone."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            bypass=True,
+            command=False,
+        )
+        self.assertIsNotNone(frame.insert_zone)
+
+    def test_bd_frame_roundtrip(self):
+        """Type-BD frame packs and unpacks correctly with SDLS."""
+        frame = make_frame(
+            b"\x01\x02",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            bypass=True,
+            command=False,
+            sequence_number=7,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
+        self.assertIsNotNone(unpacked.insert_zone)
+        self.assertTrue(unpacked.tfdf.tfdz.startswith(b"\x01\x02"))
 
     def test_bc_frame_len_is_total_minus_one(self):
         """BC frame_len field must equal total packed bytes minus one."""

--- a/tests/protocols/test_uslp.py
+++ b/tests/protocols/test_uslp.py
@@ -1,0 +1,149 @@
+"""Unit tests for USLP frame construction and parsing."""
+
+import unittest
+
+from spacepackets.uslp.defs import UslpChecksumError, UslpInvalidRawPacketOrFrameLenError
+from spacepackets.uslp.frame import FrameType
+
+from oresat_c3.protocols.edl_packet import SRC_DEST_ORESAT, EdlVcid
+from oresat_c3.protocols.sdls import verify_sdls
+from oresat_c3.protocols.uslp import make_frame, unpack_frame
+
+HMAC_KEY = b"\x00" * 32
+
+
+class TestMakeFrameUnpackFrame(unittest.TestCase):
+    """Tests for making and unpacking USLP frames."""
+
+    def _pack(self, frame):
+        return frame.pack(frame_type=FrameType.VARIABLE)
+
+    def test_ad_frame_roundtrip(self):
+        """Type-AD frame packs and unpacks with correct checksum and SDLS."""
+        frame = make_frame(
+            b"\x01\x02\x03",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=42,
+            sequence_number=5,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
+        self.assertIsNotNone(unpacked.insert_zone)
+        seq = verify_sdls(unpacked, HMAC_KEY)
+        self.assertEqual(seq, 5)
+        self.assertEqual(unpacked.tfdf.tfdz, b"\x01\x02\x03")
+
+    def test_ad_frame_len_is_total_minus_one(self):
+        """frame_len header field must equal total packed bytes minus one."""
+        frame = make_frame(
+            b"\x01\x02\x03",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=0,
+        )
+        raw = self._pack(frame)
+        self.assertEqual(frame.header.frame_len, len(raw) - 1)
+
+    def test_ad_frame_sdls(self):
+        """Type-AD frames must have SDLS trailer (in insert zone)."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=0,
+        )
+        self.assertIsNotNone(frame.insert_zone)
+
+    def test_bc_frame_roundtrip(self):
+        """Type-BC frame (no SDLS)."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            vcf_count=None,
+            bypass=True,
+            command=True,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.C3_COMMAND)
+        self.assertIsNone(unpacked.insert_zone)
+        self.assertEqual(unpacked.tfdf.tfdz, b"\x00")
+
+    def test_bc_frame_no_sdls(self):
+        """SDLS must not be applied to bypass frames."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            bypass=True,
+            command=True,
+        )
+        self.assertIsNone(frame.insert_zone)
+
+    def test_bc_frame_len_is_total_minus_one(self):
+        """BC frame_len field must equal total packed bytes minus one."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            bypass=True,
+            command=True,
+        )
+        raw = self._pack(frame)
+        self.assertEqual(frame.header.frame_len, len(raw) - 1)
+
+    def test_idle_frame_roundtrip(self):
+        """IDLE frame (no SDLS, with CLCW) packing and unpacking."""
+        clcw = b"\x00\x00\x00\x00"
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.IDLE,
+            SRC_DEST_ORESAT,
+            control_word=clcw,
+        )
+        raw = self._pack(frame)
+        unpacked = unpack_frame(raw)
+        self.assertEqual(unpacked.header.vcid, EdlVcid.IDLE)
+        self.assertIsNone(unpacked.insert_zone)
+        self.assertEqual(unpacked.op_ctrl_field, clcw)
+
+    def test_ad_invalid_fecf_raises(self):
+        """Invalid checksum (FECF) of a Type-AD frame must raise UslpChecksumError."""
+        frame = make_frame(
+            b"\xde\xad",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            hmac_key=HMAC_KEY,
+            vcf_count=1,
+        )
+        raw = bytearray(self._pack(frame))
+        raw[-1] ^= 0xFF
+        with self.assertRaises(UslpChecksumError):
+            unpack_frame(bytes(raw))
+
+    def test_bc_invalid_fecf_raises(self):
+        """Invalid checksum (FECF) of a Type-BC frame must raise UslpChecksumError."""
+        frame = make_frame(
+            b"\x00",
+            EdlVcid.C3_COMMAND,
+            SRC_DEST_ORESAT,
+            bypass=True,
+            command=True,
+        )
+        raw = bytearray(self._pack(frame))
+        raw[-1] ^= 0xFF
+        with self.assertRaises(UslpChecksumError):
+            unpack_frame(bytes(raw))
+
+    def test_too_short_raises(self):
+        """Frames shorter than TC_MIN_LEN must raise UslpInvalidRawPacketOrFrameLenError."""
+        from oresat_c3.protocols.uslp import TC_MIN_LEN
+
+        with self.assertRaises(UslpInvalidRawPacketOrFrameLenError):
+            unpack_frame(b"\x00" * (TC_MIN_LEN - 1))

--- a/tests/services/test_cop_manager.py
+++ b/tests/services/test_cop_manager.py
@@ -1,0 +1,169 @@
+"""Tests for the COP Manager."""
+
+import unittest
+from queue import SimpleQueue
+
+from ccsds_cop.cop_1 import ControlWord
+from ccsds_cop.cop_1.fop import (
+    Alert,
+    AsyncNotification,
+    AsyncNotificationType,
+    DirectiveNotification,
+    NotificationType,
+    TransferNotification,
+)
+
+from oresat_c3.protocols.edl_packet import EdlVcid
+from oresat_c3.services.cop_manager import CopManagerService, FopSupervisorState
+
+
+def _make_clcw(vcid: int, report_value: int = 0) -> ControlWord:
+    return ControlWord(vcid=vcid, report_value=report_value)
+
+
+class TestFopManagerSupervisor(unittest.TestCase):
+    """Test the FOP-1 supervisor state machine in CopManagerService."""
+
+    def setUp(self):
+        self.send_queue: SimpleQueue[bytes] = SimpleQueue()
+        self.service = CopManagerService()
+        self.fdu_queue = self.service.create_fop_service(EdlVcid.C3_COMMAND, self.send_queue)
+        self.instance = self.service._fops[EdlVcid.C3_COMMAND]
+
+    def _push_to_higher(self, notification) -> None:
+        self.instance.service.interface.to_higher.try_appendleft(notification)
+
+    def _clcw(self, report_value: int = 0) -> ControlWord:
+        return _make_clcw(EdlVcid.C3_COMMAND.value, report_value)
+
+    def _directive_notification(self, notification_type: NotificationType) -> DirectiveNotification:
+        return DirectiveNotification(
+            gvcid=self.instance.gvcid,
+            request_id=0,
+            notification_type=notification_type,
+        )
+
+    def _alert(self, alert: Alert) -> AsyncNotification:
+        return AsyncNotification(
+            gvcid=self.instance.gvcid,
+            notification_type=AsyncNotificationType.ALERT,
+            notification_qualifier=alert,
+        )
+
+    def _suspend(self) -> AsyncNotification:
+        return AsyncNotification(
+            gvcid=self.instance.gvcid,
+            notification_type=AsyncNotificationType.SUSPEND,
+            notification_qualifier=None,
+        )
+
+    def test_initiating_on_clcw(self) -> None:
+        self.assertEqual(self.instance.state, FopSupervisorState.IDLE)
+        self.service.dispatch_clcw(self._clcw())
+        self.service._process_clcw()
+        self.assertEqual(self.instance.state, FopSupervisorState.INITIATING)
+
+    def test_active_on_positive_confirm(self) -> None:
+        self.instance.state = FopSupervisorState.INITIATING
+        self._push_to_higher(self._directive_notification(NotificationType.POSITIVE_CONFIRM))
+        self.service._process_fop_higher()
+        self.assertEqual(self.instance.state, FopSupervisorState.ACTIVE)
+
+    def test_initiating_resets_recovery_attempts(self) -> None:
+        self.instance.state = FopSupervisorState.INITIATING
+        self.instance.recovery_attempts = 2
+        self._push_to_higher(self._directive_notification(NotificationType.POSITIVE_CONFIRM))
+        self.service._process_fop_higher()
+        self.assertEqual(self.instance.recovery_attempts, 0)
+
+    def test_suspend_notification(self) -> None:
+        self.instance.state = FopSupervisorState.ACTIVE
+        self._push_to_higher(self._suspend())
+        self.service._process_fop_higher()
+        self.assertEqual(self.instance.state, FopSupervisorState.SUSPENDED)
+
+    def test_active_to_recovering_on_alert(self) -> None:
+        self.instance.state = FopSupervisorState.ACTIVE
+        self._push_to_higher(self._alert(Alert.SYNCH))
+        self.service._process_fop_higher()
+        self.assertEqual(self.instance.state, FopSupervisorState.RECOVERING)
+
+    def test_suspend_to_initiating_on_clcw(self) -> None:
+        self.instance.state = FopSupervisorState.SUSPENDED
+        self.service.dispatch_clcw(self._clcw())
+        self.service._process_clcw()
+        self.assertEqual(self.instance.state, FopSupervisorState.INITIATING)
+
+    def test_recovering_on_positive_confirm(self) -> None:
+        self.instance.state = FopSupervisorState.RECOVERING
+        self._push_to_higher(self._directive_notification(NotificationType.POSITIVE_CONFIRM))
+        self.service._process_fop_higher()
+        self.assertEqual(self.instance.state, FopSupervisorState.ACTIVE)
+
+    def test_recovering_to_bd_fallback(self) -> None:
+        self.instance.state = FopSupervisorState.ACTIVE
+        for _ in range(self.service.MAX_RECOVERY_ATTEMPTS + 1):
+            self._push_to_higher(self._alert(Alert.SYNCH))
+            self.service._process_fop_higher()
+        self.assertEqual(self.instance.state, FopSupervisorState.BD_FALLBACK)
+
+    def test_term_alert_goes_to_idle(self) -> None:
+        self.instance.state = FopSupervisorState.ACTIVE
+        self.instance.recovery_attempts = self.service.MAX_RECOVERY_ATTEMPTS + 5
+        self._push_to_higher(self._alert(Alert.TERM))
+        self.service._process_fop_higher()
+        self.assertEqual(self.instance.state, FopSupervisorState.IDLE)
+
+    def test_fdus_not_drained_when_idle(self) -> None:
+        self.instance.state = FopSupervisorState.IDLE
+        self.fdu_queue.put_nowait(b"data")
+        self.service._process_fop_higher()
+        self.assertFalse(self.fdu_queue.empty())
+
+    def test_fdus_not_drained_when_initiating(self) -> None:
+        self.instance.state = FopSupervisorState.INITIATING
+        self.fdu_queue.put_nowait(b"data")
+        self.service._process_fop_higher()
+        self.assertFalse(self.fdu_queue.empty())
+
+    def test_fdus_not_drained_when_recovering(self) -> None:
+        self.instance.state = FopSupervisorState.RECOVERING
+        self.fdu_queue.put_nowait(b"data")
+        self.service._process_fop_higher()
+        self.assertFalse(self.fdu_queue.empty())
+
+    def test_fdus_not_drained_when_suspended(self) -> None:
+        self.instance.state = FopSupervisorState.SUSPENDED
+        self.fdu_queue.put_nowait(b"data")
+        self.service._process_fop_higher()
+        self.assertFalse(self.fdu_queue.empty())
+
+    def test_transfer_reject_does_not_raise(self) -> None:
+        self.instance.state = FopSupervisorState.ACTIVE
+        self._push_to_higher(
+            TransferNotification(
+                gvcid=self.instance.gvcid,
+                request_id=1,
+                notification_type=NotificationType.REJECT,
+            )
+        )
+        self.service._process_fop_higher()
+
+    def test_transfer_negative_confirm_does_not_raise(self) -> None:
+        self.instance.state = FopSupervisorState.ACTIVE
+        self._push_to_higher(
+            TransferNotification(
+                gvcid=self.instance.gvcid,
+                request_id=1,
+                notification_type=NotificationType.NEGATIVE_CONFIRM,
+            )
+        )
+        self.service._process_fop_higher()
+
+    def test_unknown_vcid_in_clcw_does_not_raise(self) -> None:
+        self.service.dispatch_clcw(_make_clcw(vcid=63))
+        self.service._process_clcw()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/test_cop_manager.py
+++ b/tests/services/test_cop_manager.py
@@ -66,26 +66,26 @@ class TestFopManagerSupervisor(unittest.TestCase):
     def test_active_on_positive_confirm(self) -> None:
         self.instance.state = FopSupervisorState.INITIATING
         self._push_to_higher(self._directive_notification(NotificationType.POSITIVE_CONFIRM))
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.state, FopSupervisorState.ACTIVE)
 
     def test_initiating_resets_recovery_attempts(self) -> None:
         self.instance.state = FopSupervisorState.INITIATING
         self.instance.recovery_attempts = 2
         self._push_to_higher(self._directive_notification(NotificationType.POSITIVE_CONFIRM))
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.recovery_attempts, 0)
 
     def test_suspend_notification(self) -> None:
         self.instance.state = FopSupervisorState.ACTIVE
         self._push_to_higher(self._suspend())
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.state, FopSupervisorState.SUSPENDED)
 
     def test_active_to_recovering_on_alert(self) -> None:
         self.instance.state = FopSupervisorState.ACTIVE
         self._push_to_higher(self._alert(Alert.SYNCH))
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.state, FopSupervisorState.RECOVERING)
 
     def test_suspend_to_initiating_on_clcw(self) -> None:
@@ -97,45 +97,45 @@ class TestFopManagerSupervisor(unittest.TestCase):
     def test_recovering_on_positive_confirm(self) -> None:
         self.instance.state = FopSupervisorState.RECOVERING
         self._push_to_higher(self._directive_notification(NotificationType.POSITIVE_CONFIRM))
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.state, FopSupervisorState.ACTIVE)
 
     def test_recovering_to_bd_fallback(self) -> None:
         self.instance.state = FopSupervisorState.ACTIVE
         for _ in range(self.service.MAX_RECOVERY_ATTEMPTS + 1):
             self._push_to_higher(self._alert(Alert.SYNCH))
-            self.service._process_fop_higher()
+            self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.state, FopSupervisorState.BD_FALLBACK)
 
     def test_term_alert_goes_to_idle(self) -> None:
         self.instance.state = FopSupervisorState.ACTIVE
         self.instance.recovery_attempts = self.service.MAX_RECOVERY_ATTEMPTS + 5
         self._push_to_higher(self._alert(Alert.TERM))
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertEqual(self.instance.state, FopSupervisorState.IDLE)
 
     def test_fdus_not_drained_when_idle(self) -> None:
         self.instance.state = FopSupervisorState.IDLE
         self.fdu_queue.put_nowait(b"data")
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertFalse(self.fdu_queue.empty())
 
     def test_fdus_not_drained_when_initiating(self) -> None:
         self.instance.state = FopSupervisorState.INITIATING
         self.fdu_queue.put_nowait(b"data")
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertFalse(self.fdu_queue.empty())
 
     def test_fdus_not_drained_when_recovering(self) -> None:
         self.instance.state = FopSupervisorState.RECOVERING
         self.fdu_queue.put_nowait(b"data")
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertFalse(self.fdu_queue.empty())
 
     def test_fdus_not_drained_when_suspended(self) -> None:
         self.instance.state = FopSupervisorState.SUSPENDED
         self.fdu_queue.put_nowait(b"data")
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
         self.assertFalse(self.fdu_queue.empty())
 
     def test_transfer_reject_does_not_raise(self) -> None:
@@ -147,7 +147,7 @@ class TestFopManagerSupervisor(unittest.TestCase):
                 notification_type=NotificationType.REJECT,
             )
         )
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
 
     def test_transfer_negative_confirm_does_not_raise(self) -> None:
         self.instance.state = FopSupervisorState.ACTIVE
@@ -158,7 +158,7 @@ class TestFopManagerSupervisor(unittest.TestCase):
                 notification_type=NotificationType.NEGATIVE_CONFIRM,
             )
         )
-        self.service._process_fop_higher()
+        self.service._process_fop_higher(self.instance)
 
     def test_unknown_vcid_in_clcw_does_not_raise(self) -> None:
         self.service.dispatch_clcw(_make_clcw(vcid=63))

--- a/tests/services/test_cop_manager.py
+++ b/tests/services/test_cop_manager.py
@@ -160,6 +160,12 @@ class TestFopManagerSupervisor(unittest.TestCase):
         )
         self.service._process_fop_higher(self.instance)
 
+    def test_bd_fallback_to_initiating_on_clcw(self) -> None:
+        self.instance.state = FopSupervisorState.BD_FALLBACK
+        self.service.dispatch_clcw(self._clcw())
+        self.service._process_clcw()
+        self.assertEqual(self.instance.state, FopSupervisorState.INITIATING)
+
     def test_unknown_vcid_in_clcw_does_not_raise(self) -> None:
         self.service.dispatch_clcw(_make_clcw(vcid=63))
         self.service._process_clcw()


### PR DESCRIPTION
This PR adds the sending end of COP-1, FOP-1, as a channel routing option. It is disabled by default.

The CopManager service handles the Higher and Lower Procedures for all FOP-1 instances. This also includes CLCWs, which are handled by the router to the manager, which then handles sending them to the correct FOP instance.

### General Operation
In a "normal" situation, where FOP-1 is the end operating on the ground, it is trivial for an operator to press a button to terminate and reactivate the FOP state machine, should retransmission time out or other alerts occur (this is how it works in YAMCS). However, on a satellite in orbit, this is not as convenient! The Higher Procedures for FOP-1 have automatic recovery actions when alerts or other problems occur, instead of forwarding them to the user. Ideally recovery takes only a few service loops, and at worst 1.5 minutes (after this timeout, FOP is reinitialized from scratch). Additionally, if FOP stops receiving CLCWs (default 3s timeout, same as YAMCS), it automatically suspends service until it has ground station contact again. 

### Usage and Drawbacks
Overall, the API is meant to be as simple as possible to users (the EDL). The EDL only has to add to a queue as before, and the FOP procedures handle everything else behind the scenes. The main drawback is that if a problem with the retransmission system *itself* occurs, there is no way to alert the user and the frames are dropped (with logged warnings). Recovery is still automatic and unless something is *really* wrong future frames will downlink just fine after recovery.

### Does it work?
I have written a batch of unit tests, which is about as good as it gets for now, since we don't have a ground station FARM implementation yet. The FOP-1 service itself works fine, as shown in #90. 