### PR TITLE
EDL test class

### DIFF
--- a/docs/edl.rst
+++ b/docs/edl.rst
@@ -24,18 +24,19 @@ EDL Packet Structure
 
 The EDL uses USLP (Unified Space Link Protocol) from CCSDS (The Consultative Committee for Space Data Systems).
 
-+--------------+---------------------+-----------------+------------+-------------------+------------+
-| USLP Primary | Sequence Number     | USLP Data Field | Payload    | HMAC              | USLP FECF  |
-| Header       |                     | Header          |            |                   |            |
-|              | (4 Octets)          |                 | (X Octets) | (32 Octets)       | (2 Octets) |
-| (7 Octets)   |                     | (1 Octet)       +------------+-------------------+            |
-|              |                     |                 | USLP Transfer Frame Data Zone  |            |
-|              +---------------------+-----------------+--------------------------------+            |
-|              | USLP Transfer Frame | USLP Transfer Frame Data Field                   |            |
-|              | Insert Zone         |                                                  |            |
-+--------------+---------------------+--------------------------------------------------+------------+
-| USLP Transfer Frame                                                                                |
-+----------------------------------------------------------------------------------------------------+
++--------------+---------------------+-----------------+---------------------+--------------+---------------+------------+
+| USLP Primary | SDLS header         | USLP Data Field | Payload             | SDLS Trailer | Operational   | USLP FECF  |
+| Header       |                     | Header          |                     |              | Control Field |            |
+|              | (6 Octets)          |                 | (X Octets)          | (32 Octets)  |               | (2 Octets) |
+| (7 Octets)   |                     | (1 Octet)       +---------------------+              | (0/4 Octets)  |            |
+|              |                     |                 | USLP Transfer Frame |              |               |            |
+|              |                     |                 | Data Zone           |              |               |            |
+|              +---------------------+-----------------+---------------------+--------------+               |            |
+|              | USLP SDLS Header    | USLP Transfer Frame Data Field                       |               |            |
+|              | (uses insert zone)  |                                                      |               |            |
++--------------+---------------------+------------------------------------------------------+---------------+------------+
+| USLP Transfer Frame                                                                                                    |
++------------------------------------------------------------------------------------------------------------------------+
 
 USLP Primary Header
 *******************
@@ -47,7 +48,8 @@ USLP Primary Header
 - **Virtual Channel ID`**: 6 bits.
    - Virtual channel ``0b000000`` is used for C3 commands.
    - Virtual channel ``0b000001`` is used for file transfer.
-- **MAP ID: 6 bits**. Not used by OreSat (will always be ``0b000000``).
+   - Virtual channel ``0b000010`` is used for empty clcw frames with no SDLS.
+- **MAP ID: 4 bits**. Not used by OreSat (will always be ``0b0000``).
 - **End of Frame Primary Header Flag**: 1 bit. Always ``0b0``.
 - **Frame Length**: 16 bits. Length of entire packet **minus** one, in octets.
 - **Bypass / Sequence Control Flag**: 1 bit. Is set to ``0b0`` to mark the packet is sequence
@@ -58,8 +60,12 @@ USLP Primary Header
 - **OCF (Operation Control Field) Flag**: 1 bit. Set to ``0b0``, to mark the OCF is not included in packet.
 - **VC Frame Count Length**: 3 bits. Is set to ``0b000`` for no VCF Count bits.
 
-Sequence Number
-***************
+SDLS Header
+***********
+
+- **Security Parameter Index**: 16 bits. A value of 1 indicates that the frame uses the oresat
+  sdls implemenation.
+- **Sequence Number**: 32 bits. The sequence number is described below.
 
 The sequence number is used to prevent repeat attacks. Is a 32-bit unsigned integer.
 
@@ -67,8 +73,7 @@ On every received packet, the C3 will increment its count. Any EDL packet receiv
 higher number that the C3 internal count, otherwise the C3 will ignore it. Number rolls over at
 ``FF FF FF FF``.
 
-The sequence number will full take up the optional TFIZ (Transfer Frame Insert Zone) part of the
-USLP Transfer Frame.
+Though out of spec, the SDLS Header is currently implemented using the USLP insert zone.
 
 USLP Data Field Header
 **********************
@@ -86,11 +91,18 @@ Payload
 Differs between types. Length can differ, but it will always be at least 1 octet. If there is
 no payload, there is no reason for the EDL packet.
 
-HMAC
-****
+SDLS Trailer
+************
 
 32 octets HMAC used for authentication. If the HMAC fails, the packet will be rejected and no response
 will be sent back. For HMAC basics, see https://en.wikipedia.org/wiki/HMAC.
+
+Though out of spec, the SDLS Trailer is currently inserted into the end of data zone.
+
+Operational Control Field
+*************************
+
+4 octets. The Operational Control Field is used by COP-1 to transfer COP-1 data
 
 FECF (Frame Error Control Field)
 ********************************

--- a/docs/edl.rst
+++ b/docs/edl.rst
@@ -23,6 +23,8 @@ EDL Packet Structure
 --------------------
 
 The EDL uses USLP (Unified Space Link Protocol) from CCSDS (The Consultative Committee for Space Data Systems).
+It uses SDLS (Space Data Link Security) for authentication and COP-1 (Communication Operation Proceedure-1) for
+frame retransmission.
 
 +--------------+---------------------+-----------------+---------------------+--------------+---------------+------------+
 | USLP Primary | SDLS header         | USLP Data Field | Payload             | SDLS Trailer | Operational   | USLP FECF  |
@@ -31,10 +33,10 @@ The EDL uses USLP (Unified Space Link Protocol) from CCSDS (The Consultative Com
 | (7 Octets)   |                     | (1 Octet)       +---------------------+              | (0/4 Octets)  |            |
 |              |                     |                 | USLP Transfer Frame |              |               |            |
 |              |                     |                 | Data Zone           |              |               |            |
-|              +---------------------+-----------------+---------------------+--------------+               |            |
-|              | USLP SDLS Header    | USLP Transfer Frame Data Field                       |               |            |
-|              | (uses insert zone)  |                                                      |               |            |
-+--------------+---------------------+------------------------------------------------------+---------------+------------+
+|              +---------------------+-----------------+---------------------+              |               |            |
+|              | USLP SDLS Header    | USLP Transfer Frame Data Field        |              |               |            |
+|              | (uses insert zone)  |                                       |              |               |            |
++--------------+---------------------+---------------------------------------+--------------+---------------+------------+
 | USLP Transfer Frame                                                                                                    |
 +------------------------------------------------------------------------------------------------------------------------+
 

--- a/oresat_c3/protocols/edl_command.py
+++ b/oresat_c3/protocols/edl_command.py
@@ -277,6 +277,12 @@ class EdlCommandCode(IntEnum):
 
     Returns
     -------
+    uint8
+        The id of The CANopen node read.
+    uint16
+        The OD index read.
+    uint8
+        The OD subindex read.
     uint32
         SDO error code (0 is no error).
     uint32

--- a/oresat_c3/protocols/edl_command.py
+++ b/oresat_c3/protocols/edl_command.py
@@ -363,7 +363,7 @@ EDL_COMMANDS = {
     EdlCommandCode.C3_SOFT_RESET: EdlCommand(),
     EdlCommandCode.C3_HARD_RESET: EdlCommand(),
     EdlCommandCode.C3_FACTORY_RESET: EdlCommand(),
-    EdlCommandCode.CO_NODE_ENABLE: EdlCommand("B?", "B"),
+    EdlCommandCode.CO_NODE_ENABLE: EdlCommand(),
     EdlCommandCode.CO_NODE_STATUS: EdlCommand("B", "B"),
     EdlCommandCode.CO_SDO_WRITE: EdlCommand(
         None, "I", _edl_req_sdo_write_pack_cb, _edl_req_sdo_write_unpack_cb

--- a/oresat_c3/protocols/edl_command.py
+++ b/oresat_c3/protocols/edl_command.py
@@ -9,7 +9,7 @@ request, and values for responses.
 
 import struct
 from collections import namedtuple
-from enum import IntEnum, auto
+from enum import IntEnum
 
 EdlCommand = namedtuple(
     "EdlCommand",
@@ -56,39 +56,27 @@ class EdlCommandCode(IntEnum):
         Tx status
     """
 
-    C3_SOFT_RESET = auto()
+    C3_SOFT_RESET = 1
     """
     Soft reset the C3 (reboot C3 daemon).
     """
 
-    C3_HARD_RESET = auto()
+    C3_HARD_RESET = 2
     """
     Hard reset the C3 (reboot system).
     """
 
-    C3_FACTORY_RESET = auto()
+    C3_FACTORY_RESET = 3
     """
     Factory reset the C3 (clear FRAM, reset RTC, and reboot system).
     """
 
-    CO_NODE_ENABLE = auto()
+    CO_NODE_ENABLE = 4
     """
-    Enable a CANopen node.
-
-    Parameters
-    ----------
-    node_id: uint8
-        Node id of the CANopen node to enable / disable
-    enable: bool
-        True to enable or False to disable
-
-    Returns
-    -------
-    uint8
-        node status
+    Vestigial command to turn on CANopen in a node. CANopen is always on, so this has no use.
     """
 
-    CO_NODE_STATUS = auto()
+    CO_NODE_STATUS = 5
     """
     Get the status of a CANopen node.
 
@@ -103,7 +91,7 @@ class EdlCommandCode(IntEnum):
         node status
     """
 
-    CO_SDO_WRITE = auto()
+    CO_SDO_WRITE = 6
     """
     Write a value to a node's OD over the CAN bus using a CANopen SDO message.
 
@@ -126,7 +114,7 @@ class EdlCommandCode(IntEnum):
         SDO error code (0 is no error).
     """
 
-    CO_SYNC = auto()
+    CO_SYNC = 7
     """
     Send a CANopen SYNC message on the CAN bus.
 
@@ -136,7 +124,7 @@ class EdlCommandCode(IntEnum):
         The CANopen SYNC message was sent successfully.
     """
 
-    OPD_SYSENABLE = auto()
+    OPD_SYSENABLE = 8
     """
     Enable the OPD subsystem.
 
@@ -151,7 +139,7 @@ class EdlCommandCode(IntEnum):
         OPD subsystem status.
     """
 
-    OPD_SCAN = auto()
+    OPD_SCAN = 9
     """
     Scan for all nodes on the OPD.
 
@@ -161,7 +149,7 @@ class EdlCommandCode(IntEnum):
         The number of nodes found.
     """
 
-    OPD_PROBE = auto()
+    OPD_PROBE = 10
     """
     Probe for a node on the OPD.
 
@@ -176,7 +164,7 @@ class EdlCommandCode(IntEnum):
         True if the node was found or False if not.
     """
 
-    OPD_ENABLE = auto()
+    OPD_ENABLE = 11
     """
     Enable / disable a node on the OPD.
 
@@ -193,7 +181,7 @@ class EdlCommandCode(IntEnum):
         OPD node status. See the OPD page.
     """
 
-    OPD_RESET = auto()
+    OPD_RESET = 12
     """
     Reset a node on the OPD.
 
@@ -208,7 +196,7 @@ class EdlCommandCode(IntEnum):
         OPD node status. See the OPD page.
     """
 
-    OPD_STATUS = auto()
+    OPD_STATUS = 13
     """
     Get the status of a node on the OPD.
 
@@ -223,7 +211,7 @@ class EdlCommandCode(IntEnum):
         OPD node status. See the OPD page.
     """
 
-    RTC_SET_TIME = auto()
+    RTC_SET_TIME = 14
     """
     Set the RTC time
 
@@ -238,7 +226,7 @@ class EdlCommandCode(IntEnum):
         The RTC time was set successfully.
     """
 
-    TIME_SYNC = auto()
+    TIME_SYNC = 15
     """
     C3 will send OreSat's Time Sync TPDO over the CAN bus (all nodes that are powered on and care
     about time will sync to it).
@@ -249,12 +237,12 @@ class EdlCommandCode(IntEnum):
         Time sync was sent.
     """
 
-    BEACON_PING = auto()
+    BEACON_PING = 16
     """
     C3 will response with a beacon regardless of tx state.
     """
 
-    PING = auto()
+    PING = 17
     """
     A basic ping to the C3.
 
@@ -269,12 +257,12 @@ class EdlCommandCode(IntEnum):
         The parameter value.
     """
 
-    RX_TEST = auto()
+    RX_TEST = 18
     """
     Empty command for C3 Rx testing.
     """
 
-    CO_SDO_READ = auto()
+    CO_SDO_READ = 19
     """
     Read a value from a node's OD over the CAN bus using a CANopen SDO message.
 
@@ -297,7 +285,7 @@ class EdlCommandCode(IntEnum):
         Data buffer.
     """
 
-    CO_NODE_FLASH = auto()
+    CO_NODE_FLASH = 20
     """
     Flash a Zephyr/mcuboot image to a node using CANopen block or segmented download.
 

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -181,6 +181,9 @@ class EdlService(Service):
             try:
                 res_payload = self._run_cmd(req_packet.payload)
                 if not res_payload.values:
+                    logger.info(
+                        f"EDL dropping command response with no values. ID: {res_payload.code.name}"
+                    )
                     return  # no response
                 self._respond(EdlVcid.C3_COMMAND, res_payload)
             except Exception as e:  # pylint: disable=W0718
@@ -312,11 +315,12 @@ class EdlService(Service):
         elif request.code == EdlCommandCode.RTC_SET_TIME:
             ts = request.args[0]
             logger.info(f"EDL setting the RTC time to {ts}")
-            set_rtc_time(ts)
-            set_system_time_to_rtc_time()
+            ret = set_rtc_time(ts)
+            ret = ret and set_system_time_to_rtc_time()
         elif request.code == EdlCommandCode.TIME_SYNC:
             logger.info("EDL sending time sync TPDO")
             self.node.send_tpdo(0)
+            ret = True
         elif request.code == EdlCommandCode.BEACON_PING:
             logger.info("EDL beacon")
             self._beacon_service.send()

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -239,9 +239,7 @@ class EdlService(Service):
             logger.info("EDL factory reset")
             self.node.stop(NodeStop.FACTORY_RESET)
         elif request.code == EdlCommandCode.CO_NODE_ENABLE:
-            node_id = request.args[0]
-            name = self._node_mgr_service.node_id_to_name[node_id]
-            logger.info(f"EDL enabling CANopen node {name} (0x{node_id:02X})")
+            logger.warning("EDL got CO_NODE_ENABLE, which is vestigial and should not be used.")
         elif request.code == EdlCommandCode.CO_NODE_STATUS:
             node_id = request.args[0]
             name = self._node_mgr_service.node_id_to_name[node_id]
@@ -270,6 +268,7 @@ class EdlService(Service):
         elif request.code == EdlCommandCode.CO_SYNC:
             logger.info("EDL sending CANopen SYNC message")
             self.node.send_sync()
+            ret = True
         elif request.code == EdlCommandCode.OPD_SYSENABLE:
             enable = request.args[0]
             if enable:

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -360,6 +360,7 @@ class EdlService(Service):
             except canopen.sdo.exceptions.SdoAbortedError as e:
                 logger.error(e)
                 ecode = e.code
+                data = bytes("ERROR", "utf-8")
             ret = (node_id, index, subindex, ecode, len(data), data)
         elif request.code == EdlCommandCode.CO_NODE_FLASH:
             node_id, filename, throttle_delay, block_transfer, request_crc, confirm_image = (

--- a/oresat_c3/services/edl.py
+++ b/oresat_c3/services/edl.py
@@ -246,7 +246,7 @@ class EdlService(Service):
             node_id = request.args[0]
             name = self._node_mgr_service.node_id_to_name[node_id]
             logger.info(f"EDL getting CANopen node {name} (0x{node_id:02X}) status")
-            ret = self.node.node_status[name]
+            ret = self.node.node_status[name].state
         elif request.code == EdlCommandCode.CO_SDO_WRITE:
             node_id, index, subindex, _, data = request.args
             name = self._node_mgr_service.node_id_to_name[node_id]

--- a/oresat_c3/subsystems/rtc.py
+++ b/oresat_c3/subsystems/rtc.py
@@ -30,7 +30,7 @@ def get_rtc_time() -> float:
     return ts
 
 
-def set_rtc_time(ts: float):
+def set_rtc_time(ts: float) -> bool:
     """
     Set the RTC time.
 
@@ -45,10 +45,10 @@ def set_rtc_time(ts: float):
     rtc_path = "/dev/rtc"
     if not os.path.exists(rtc_path):
         logger.error("RTC does not exist")
-        return
+        return False
     if os.geteuid() != 0:
         logger.error("failed to set RTC time due to permission error")
-        return
+        return False
 
     if ts < 946713600:  # Januay 1, 2000 midnight
         values = (0, 0, 0, 1, 0, 100, 0, 0, 0)
@@ -59,6 +59,7 @@ def set_rtc_time(ts: float):
     raw = struct.pack("9i", *values)
     with open(rtc_path) as f:
         ioctl(f, 0x4024700A, raw)  # magic number is the ioctl request code to set rtc time
+    return True
 
 
 def set_rtc_time_to_system_time():
@@ -72,16 +73,19 @@ def set_rtc_time_to_system_time():
         set_rtc_time(time())
 
 
-def set_system_time_to_rtc_time():
+def set_system_time_to_rtc_time() -> bool:
     """
     Set the system time to the RTC time.
     """
 
     if os.geteuid() != 0:
         logger.error("failed to set system time from RTC time due to permission error")
+        return False
     else:
         ts = get_rtc_time()
         if ts < 0:
             logger.error("RTC does not exist")
+            return False
         else:
             clock_settime(CLOCK_REALTIME, ts)
+            return True

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -8,13 +8,14 @@ returning correctly, the commands have the desired result.
 import unittest
 from queue import SimpleQueue
 from time import sleep, time
-from typing import Optional
+from typing import NamedTuple, Optional
 
+from canopen.sdo.exceptions import SdoAbortedError
 from olaf import CanNetwork, MasterNode, NodeStop
 from oresat_configs import Mission, OreSatConfig
 from spacepackets.uslp import TransferFrame
 
-from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest
+from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest, EdlCommandResponse
 from oresat_c3.protocols.edl_packet import EdlPacket, EdlVcid
 from oresat_c3.protocols.uslp import make_frame, unpack_frame
 from oresat_c3.services.beacon import BeaconService
@@ -26,9 +27,18 @@ from oresat_c3.subsystems.opd import OpdNodeState
 
 HMAC = bytes(32)
 
-def make_packet_frame(cmd: EdlCommandCode, values: tuple | None) -> TransferFrame:
+class NodeHeartbeatInfo(NamedTuple):
+    state: int
+    timestamp: float
+    time_since_boot: float
+
+def make_cmd(cmd: EdlCommandCode, values: tuple | None, q: SimpleQueue) -> TransferFrame:
     payload = EdlCommandRequest(cmd, values).pack()
-    return make_frame(payload, 0, 1, hmac_key=HMAC)
+    frame = make_frame(payload, 0, 1, hmac_key=HMAC)
+    q.put(frame)
+
+def to_response(resp_raw: bytes) -> EdlCommandResponse:
+    return EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
 
 class TestEdl(unittest.TestCase):
     """Test the C3 state service."""
@@ -67,22 +77,20 @@ class TestEdl(unittest.TestCase):
         start_time = int(time())
 
         # enable
-        frame = make_packet_frame(EdlCommandCode.TX_CTRL, (True,))
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.TX_CTRL, (True,), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
-        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+        response = to_response(resp_raw)
         self.assertEqual(response.code, EdlCommandCode.TX_CTRL)
         self.assertEqual(response.values[0], (True))
         self.assertEqual(tx_enable.value, True)
         self.assertTrue(start_time >= last_enable.value)
 
         # disable
-        frame = make_packet_frame(EdlCommandCode.TX_CTRL, (False,))
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.TX_CTRL, (False,), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
-        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+        response = to_response(resp_raw)
         self.assertEqual(response.code, EdlCommandCode.TX_CTRL)
         self.assertEqual(response.values[0], (False))
         self.assertEqual(tx_enable.value, False)
@@ -92,8 +100,7 @@ class TestEdl(unittest.TestCase):
         """1: No inputs. Should edit self.node.value_set_by_edl. Should not reply."""
         self.node.value_set_by_edl = NodeStop.NO_STOP
 
-        frame = make_packet_frame(EdlCommandCode.C3_SOFT_RESET, ())
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.C3_SOFT_RESET, (), self.mock_router.uplink_edl)
         sleep(0.1)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         self.assertEqual(self.node.value_set_by_edl, NodeStop.SOFT_RESET)
@@ -102,8 +109,7 @@ class TestEdl(unittest.TestCase):
         """2: No inputs. Should edit self.node.value_set_by_edl. Should not reply."""
         self.node.value_set_by_edl = NodeStop.NO_STOP
 
-        frame = make_packet_frame(EdlCommandCode.C3_HARD_RESET, ())
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.C3_HARD_RESET, (), self.mock_router.uplink_edl)
         sleep(0.1)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         self.assertEqual(self.node.value_set_by_edl, NodeStop.HARD_RESET)
@@ -112,39 +118,127 @@ class TestEdl(unittest.TestCase):
         """3: No inputs. Should edit self.node.value_set_by_edl. Should not reply."""
         self.node.value_set_by_edl = NodeStop.NO_STOP
 
-        frame = make_packet_frame(EdlCommandCode.C3_FACTORY_RESET, ())
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.C3_FACTORY_RESET, (), self.mock_router.uplink_edl)
         sleep(0.1)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         self.assertEqual(self.node.value_set_by_edl, NodeStop.FACTORY_RESET)
+
+    def test_co_node_enable_reset(self):
+        """4: Vestigal and no longer used."""
+        pass
+
+    def test_co_node_status(self):
+        """5: 1 input. returns the heartbeat status of the relevant node."""
+        self.node.node_status["star_tracker_1"] = NodeHeartbeatInfo(0x05, 0,0)
+
+        make_cmd(EdlCommandCode.CO_NODE_STATUS, (0x2C,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_NODE_STATUS)
+        self.assertEqual(response.values[0], 0x05)
+
+    def test_co_sdo_write_local(self):
+        """6: 5 inputs. expect a uint32 back with the error code, 0 if none. Tests writing to c3."""
+        od_val = self.node.od["reset_timeout"]
+        od_val.value = 10000
+
+        make_cmd(
+            EdlCommandCode.CO_SDO_WRITE,
+            (0x1,0x4001,0x0,0x4,(20000).to_bytes(4, "little")),
+            self.mock_router.uplink_edl
+        )
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SDO_WRITE)
+        self.assertEqual(response.values[0], (0x0))
+        self.assertEqual(int(od_val.value), 20000)
+
+    def test_co_sdo_write_remote(self):
+        """
+        6: 5 inputs. expect a uint32 back with the error code, 0 if none. Tests "writing" to star
+        tracker. Does not actually write, just sets value_set_by_edl = True
+        """
+        self.node.should_fail_test = False
+        self.node.value_set_by_edl = False
+
+        make_cmd(
+            EdlCommandCode.CO_SDO_WRITE,
+            (0x2C,0x4000,0x0,0x1,(2).to_bytes(1, "little")),
+            self.mock_router.uplink_edl
+        )
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SDO_WRITE)
+        self.assertEqual(response.values[0], (0x0))
+        self.assertEqual(self.node.value_set_by_edl, True)
+
+    def test_co_sdo_write_fail(self):
+        """
+        6: 5 inputs. expect a uint32 back with the error code, 0 if none. This should fail and
+        return nonzero error code.
+        """
+        self.node.should_fail_test = True
+        self.node.value_set_by_edl = False
+
+        make_cmd(
+            EdlCommandCode.CO_SDO_WRITE,
+            (0x2C,0x4000,0x0,0x1,(2).to_bytes(4, "little")),
+            self.mock_router.uplink_edl
+        )
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SDO_WRITE)
+        self.assertEqual(response.values[0], (0x05040000))
+        self.assertEqual(self.node.value_set_by_edl, True)
+
+    def test_co_sync(self):
+        """7: sends a CO sync message. """
+        self.node.value_set_by_edl = False
+
+        make_cmd(EdlCommandCode.CO_SYNC,(),self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SYNC)
+        self.assertEqual(response.values[0], True)
+        self.assertEqual(self.node.value_set_by_edl, True)
+
+
+
+
+
 
     def test_opd_node_enable(self):
         """11: Takes 2 values, nodeid and value. Sends two commands to test both states."""
         self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.DISABLED
 
         # enable
-        frame = make_packet_frame(EdlCommandCode.OPD_ENABLE, (0x1C, True))
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.OPD_ENABLE, (0x1C, True), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
-        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
-        self.assertEqual(response.code,EdlCommandCode.OPD_ENABLE)
-        self.assertEqual(response.values[0],(0x1))
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_ENABLE)
+        self.assertEqual(response.values[0], (0x1))
         self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].status, OpdNodeState.ENABLED)
 
         # disable
-        frame = make_packet_frame(EdlCommandCode.OPD_ENABLE, (0x1C, False))
-        self.mock_router.uplink_edl.put(frame)
+        make_cmd(EdlCommandCode.OPD_ENABLE, (0x1C, False), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
-        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
-        self.assertEqual(response.code,EdlCommandCode.OPD_ENABLE)
-        self.assertEqual(response.values[0],(0x0))
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_ENABLE)
+        self.assertEqual(response.values[0], (0x0))
         self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].status, OpdNodeState.DISABLED)
 
 
+
+
 class MockMasterNode(MasterNode):
-    """MasterNode wrapper with an overwritten stop function. No type definitions to limit imports"""
+    """MasterNode wrapper with overwritten functions that let us ensure that they are called."""
     def __init__(
         self,
         network,
@@ -152,10 +246,24 @@ class MockMasterNode(MasterNode):
         od_db,
     ) -> None:
         super().__init__(network, od, od_db)
+        self.should_fail_test = False
 
     def stop(self, reset: NodeStop | None = None):
         self.value_set_by_edl = reset
 
+    def sdo_write(
+        self,
+        key: str,
+        index: int | str,
+        subindex: int | str | None,
+        value: str | float | bytes | bool,
+    ) -> None:
+        self.value_set_by_edl = True
+        if self.should_fail_test:
+            raise SdoAbortedError(0x05040000)
+
+    def send_sync(self):
+        self.value_set_by_edl = True
 
 class MockNodeFlasherService(NodeFlasherService):
     """Cut down node flasher service to test if commands have the desired effect"""
@@ -228,7 +336,8 @@ class MockNode():
                 return self.status
 
             def probe(self) -> bool:
-                return self.status == OpdNodeState.NOT_FOUND
+                """intent is that status is manually set prior to CMD."""
+                return self.status
 
             def reset(self) -> OpdNodeState:
                 self.status = OpdNodeState.ENABLED
@@ -262,8 +371,8 @@ class MockNodeManagerService(NodeManagerService):
     def __init__(self):
         self.set_node = 0x0
         self.set_state = 0x0
-        self.opd_addr_to_name = {0x1C: "star_tracker_1"}
-        self.node_id_to_name = {0x1C: "star_tracker_1"}
+        self.opd_addr_to_name = {0x0: "c3", 0x1C: "star_tracker_1"}
+        self.node_id_to_name = {0x1: "c3", 0x2C: "star_tracker_1"}
         self.opd = MockOpd()
 
     def __del__(self):

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -318,6 +318,52 @@ class TestEdl(unittest.TestCase):
         self.assertEqual(response.code, EdlCommandCode.OPD_STATUS)
         self.assertEqual(response.values[0], 0x0)
 
+    def test_set_rtc(self):
+        """
+        14. 1 input. FIXME: I'm not aware of a way to test that rtc is actually being called, so
+        this just checks to make sure that the command parses correctly.
+        """
+        make_cmd(EdlCommandCode.RTC_SET_TIME, (2253690377,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.RTC_SET_TIME)
+        self.assertEqual(response.values[0], False)
+
+    def test_time_sync(self):
+        """15: No input. Tests to make sure that calling send_tpdo is occurs, not that it works."""
+        self.node.value_set_by_edl = False
+
+        make_cmd(EdlCommandCode.TIME_SYNC, (), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.TIME_SYNC)
+        self.assertEqual(response.values[0], True)
+        self.assertEqual(self.node.value_set_by_edl, True)
+
+    def test_beacon_ping(self):
+        """16: No input. No output. Tells the beacon service to send a beacon."""
+        self.beacon.told_to_beacon = False
+
+        make_cmd(EdlCommandCode.BEACON_PING, (), self.mock_router.uplink_edl)
+        sleep(1)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        self.assertEqual(self.beacon.told_to_beacon, True)
+
+    def test_ping(self):
+        """15: No input. Tests to make sure that calling send_tpdo is occurs, not that it works."""
+        val = 536
+
+        make_cmd(EdlCommandCode.PING, (val,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.PING)
+        self.assertEqual(response.values[0], val)
+
+
+
 
 class MockMasterNode(MasterNode):
     """MasterNode wrapper with overwritten functions that let us ensure that they are called."""
@@ -345,6 +391,9 @@ class MockMasterNode(MasterNode):
             raise SdoAbortedError(0x05040000)
 
     def send_sync(self):
+        self.value_set_by_edl = True
+
+    def send_tpdo(self, tpdo: int, raise_error: bool = True) -> None:
         self.value_set_by_edl = True
 
 

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -27,18 +27,22 @@ from oresat_c3.subsystems.opd import OpdNodeState, OpdState
 
 HMAC = bytes(32)
 
+
 class NodeHeartbeatInfo(NamedTuple):
     state: int
     timestamp: float
     time_since_boot: float
 
-def make_cmd(cmd: EdlCommandCode, values: tuple | None, q: SimpleQueue) -> TransferFrame:
+
+def make_cmd(cmd: EdlCommandCode, values: tuple, q: SimpleQueue) -> TransferFrame:
     payload = EdlCommandRequest(cmd, values).pack()
     frame = make_frame(payload, 0, 1, hmac_key=HMAC)
     q.put(frame)
 
+
 def to_response(resp_raw: bytes) -> EdlCommandResponse:
     return EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+
 
 class TestEdl(unittest.TestCase):
     """Test the C3 state service."""
@@ -134,7 +138,7 @@ class TestEdl(unittest.TestCase):
 
     def test_co_node_status(self):
         """5: 1 input. returns the heartbeat status of the relevant node."""
-        self.node.node_status["star_tracker_1"] = NodeHeartbeatInfo(0x05, 0,0)
+        self.node.node_status["star_tracker_1"] = NodeHeartbeatInfo(0x05, 0, 0)
 
         make_cmd(EdlCommandCode.CO_NODE_STATUS, (0x2C,), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
@@ -150,8 +154,8 @@ class TestEdl(unittest.TestCase):
 
         make_cmd(
             EdlCommandCode.CO_SDO_WRITE,
-            (0x1,0x4001,0x0,0x4,(20000).to_bytes(4, "little")),
-            self.mock_router.uplink_edl
+            (0x1, 0x4001, 0x0, 0x4, (20000).to_bytes(4, "little")),
+            self.mock_router.uplink_edl,
         )
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
@@ -170,8 +174,8 @@ class TestEdl(unittest.TestCase):
 
         make_cmd(
             EdlCommandCode.CO_SDO_WRITE,
-            (0x2C,0x4000,0x0,0x1,(2).to_bytes(1, "little")),
-            self.mock_router.uplink_edl
+            (0x2C, 0x4000, 0x0, 0x1, (2).to_bytes(1, "little")),
+            self.mock_router.uplink_edl,
         )
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
@@ -190,8 +194,8 @@ class TestEdl(unittest.TestCase):
 
         make_cmd(
             EdlCommandCode.CO_SDO_WRITE,
-            (0x2C,0x4000,0x0,0x1,(2).to_bytes(4, "little")),
-            self.mock_router.uplink_edl
+            (0x2C, 0x4000, 0x0, 0x1, (2).to_bytes(4, "little")),
+            self.mock_router.uplink_edl,
         )
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
@@ -201,10 +205,10 @@ class TestEdl(unittest.TestCase):
         self.assertEqual(self.node.value_set_by_edl, True)
 
     def test_co_sync(self):
-        """7: sends a CO sync message. """
+        """7: sends a CO sync message."""
         self.node.value_set_by_edl = False
 
-        make_cmd(EdlCommandCode.CO_SYNC,(),self.mock_router.uplink_edl)
+        make_cmd(EdlCommandCode.CO_SYNC, (), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         response = to_response(resp_raw)
@@ -378,7 +382,7 @@ class TestEdl(unittest.TestCase):
         od_val = self.node.od["reset_timeout"]
         od_val.value = 10000
 
-        make_cmd(EdlCommandCode.CO_SDO_READ, (0x1,0x4001,0x0), self.mock_router.uplink_edl)
+        make_cmd(EdlCommandCode.CO_SDO_READ, (0x1, 0x4001, 0x0), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         response = to_response(resp_raw)
@@ -394,11 +398,7 @@ class TestEdl(unittest.TestCase):
         """19: 3 inputs. 3 outputs. Tests reading a remote index."""
         self.node.should_fail_test = False
 
-        make_cmd(
-            EdlCommandCode.CO_SDO_READ,
-            (0x2C,0x4000,0x0),
-            self.mock_router.uplink_edl
-        )
+        make_cmd(EdlCommandCode.CO_SDO_READ, (0x2C, 0x4000, 0x0), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         response = to_response(resp_raw)
@@ -414,11 +414,7 @@ class TestEdl(unittest.TestCase):
         """19: 3 inputs. 3 outputs. Tests failing to read a remote index."""
         self.node.should_fail_test = True
 
-        make_cmd(
-            EdlCommandCode.CO_SDO_READ,
-            (0x2C,0x4000,0x0),
-            self.mock_router.uplink_edl
-        )
+        make_cmd(EdlCommandCode.CO_SDO_READ, (0x2C, 0x4000, 0x0), self.mock_router.uplink_edl)
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
         response = to_response(resp_raw)
@@ -434,8 +430,8 @@ class TestEdl(unittest.TestCase):
         """20: 2-6 inputs. 1 output."""
         make_cmd(
             EdlCommandCode.CO_NODE_FLASH,
-            (0x2C,"name1",536,True,False,True),
-            self.mock_router.uplink_edl
+            (0x2C, "name1", 536, True, False, True),
+            self.mock_router.uplink_edl,
         )
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
         self.assertTrue(self.mock_router.downlink_edl.empty())
@@ -455,12 +451,13 @@ class TestEdl(unittest.TestCase):
         NOTE: If you add a new command and fail this test, please add tests for the new command
         and increment this value.
         """
-        NUMBER_OF_COMMANDS=21
-        self.assertEqual(len(EdlCommandCode),NUMBER_OF_COMMANDS)
+        NUMBER_OF_COMMANDS = 21
+        self.assertEqual(len(EdlCommandCode), NUMBER_OF_COMMANDS)
 
 
 class MockMasterNode(MasterNode):
     """MasterNode wrapper with overwritten functions that let us ensure that they are called."""
+
     def __init__(
         self,
         network,
@@ -500,6 +497,7 @@ class MockMasterNode(MasterNode):
 
 class MockNodeFlasherService(NodeFlasherService):
     """Cut down node flasher service to test if commands have the desired effect"""
+
     def __init__(self):
         self.told_to_flash = False
 
@@ -526,6 +524,7 @@ class MockNodeFlasherService(NodeFlasherService):
 
 class MockChannelRouterService(ChannelRouterService):
     """Cut down channel router with queues to make sure responses are correct."""
+
     def __init__(self):
         self.uplink_edl = SimpleQueue()
         self.uplink_cfdp = SimpleQueue()
@@ -561,48 +560,48 @@ class MockBeaconService(BeaconService):
         self.told_to_beacon = True
 
 
-class MockNode():
-            def __init__(self) -> None:
-                self.status = OpdNodeState.NOT_FOUND
+class MockNode:
+    def __init__(self) -> None:
+        self.status = OpdNodeState.NOT_FOUND
 
-            def enable(self) -> OpdNodeState:
-                self.status = OpdNodeState.ENABLED
-                return self.status
+    def enable(self) -> OpdNodeState:
+        self.status = OpdNodeState.ENABLED
+        return self.status
 
-            def disable(self) -> OpdNodeState:
-                self.status = OpdNodeState.DISABLED
-                return self.status
+    def disable(self) -> OpdNodeState:
+        self.status = OpdNodeState.DISABLED
+        return self.status
 
-            def probe(self) -> bool:
-                """intent is that status is manually set prior to CMD."""
-                return self.status != OpdNodeState.NOT_FOUND
+    def probe(self) -> bool:
+        """intent is that status is manually set prior to CMD."""
+        return self.status != OpdNodeState.NOT_FOUND
 
-            def reset(self) -> OpdNodeState:
-                self.status = OpdNodeState.ENABLED
-                self.was_reset = True
-                return self.status
+    def reset(self) -> OpdNodeState:
+        self.status = OpdNodeState.ENABLED
+        self.was_reset = True
+        return self.status
 
 
-class MockOpd():
-        def __init__(self):
-            self.enabled = False
-            self._nodes: dict[str, MockNode] = {}
-            self._nodes["star_tracker_1"] = MockNode()
-            self.status = OpdState.ENABLED
+class MockOpd:
+    def __init__(self):
+        self.enabled = False
+        self._nodes: dict[str, MockNode] = {}
+        self._nodes["star_tracker_1"] = MockNode()
+        self.status = OpdState.ENABLED
 
-        def __getitem__(self, name: str) -> MockNode:
-            return self._nodes[name]
+    def __getitem__(self, name: str) -> MockNode:
+        return self._nodes[name]
 
-        def enable(self):
-            self.enabled = True
-            self.status = OpdState.ENABLED
+    def enable(self):
+        self.enabled = True
+        self.status = OpdState.ENABLED
 
-        def disable(self):
-            self.enabled = False
-            self.status = OpdState.DISABLED
+    def disable(self):
+        self.enabled = False
+        self.status = OpdState.DISABLED
 
-        def scan(self) -> int:
-            return 2
+    def scan(self) -> int:
+        return 2
 
 
 class MockNodeManagerService(NodeManagerService):
@@ -610,6 +609,7 @@ class MockNodeManagerService(NodeManagerService):
     Cut down node manager that keeps track of last command. Will only contain information for star
     tracker 1 (arbitrary), and so if further tests are desired this should be changed.
     """
+
     def __init__(self):
         self.set_node = 0x0
         self.set_state = 0x0
@@ -619,4 +619,3 @@ class MockNodeManagerService(NodeManagerService):
 
     def __del__(self):
         pass
-

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -470,11 +470,6 @@ class MockMasterNode(MasterNode):
         self.should_fail_test = False
 
     def stop(self, reset: NodeStop | None = None):
-        """
-        FIXME: This should be `def stop(self, reset: NodeStop | None = None):` but the git testing
-        environment uses an older version of python that does not support it. This should be changed
-        once the tests reflect the current python version.
-        """
         self.value_set_by_edl = reset
 
     def sdo_write(

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -1,15 +1,20 @@
-"""Class to test that the edl service is handling commands correctly"""
+"""
+Class to test that the edl service is handling commands correctly
 
-import time
+Creats a lot of mock classes that report values so that we know that, as well as parsing and
+returning correctly, the commands have the desired result.
+"""
+
 import unittest
 from queue import SimpleQueue
+from time import sleep, time
 from typing import Optional
 
-from olaf import CanNetwork, MasterNode
+from olaf import CanNetwork, MasterNode, NodeStop
 from oresat_configs import Mission, OreSatConfig
 from spacepackets.uslp import TransferFrame
 
-from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest, EdlCommandResponse
+from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest
 from oresat_c3.protocols.edl_packet import EdlPacket, EdlVcid
 from oresat_c3.protocols.uslp import make_frame, unpack_frame
 from oresat_c3.services.beacon import BeaconService
@@ -21,7 +26,7 @@ from oresat_c3.subsystems.opd import OpdNodeState
 
 HMAC = bytes(32)
 
-def make_packet_frame(cmd: EdlCommandCode, values: tuple) -> TransferFrame:
+def make_packet_frame(cmd: EdlCommandCode, values: tuple | None) -> TransferFrame:
     payload = EdlCommandRequest(cmd, values).pack()
     return make_frame(payload, 0, 1, hmac_key=HMAC)
 
@@ -29,15 +34,15 @@ class TestEdl(unittest.TestCase):
     """Test the C3 state service."""
 
     def setUp(self):
+        config = OreSatConfig(Mission.default())
+        self.od = config.od_db["c3"]
+        network = CanNetwork("virtual", "vcan0")
+        self.node = MockMasterNode(network, self.od, config.od_db)
+
         self.mock_node_mgr = MockNodeManagerService()
         self.beacon = MockBeaconService()
         self.mock_router = MockChannelRouterService()
         self.mock_flasher = MockNodeFlasherService()
-
-        config = OreSatConfig(Mission.default())
-        self.od = config.od_db["c3"]
-        network = CanNetwork("virtual", "vcan0")
-        self.node = MasterNode(network, self.od, config.od_db)
 
         self.service = EdlService(
             self.node, self.mock_node_mgr, self.beacon, self.mock_router, self.mock_flasher
@@ -53,20 +58,103 @@ class TestEdl(unittest.TestCase):
         self.service._event.set()
         self.service.stop()
 
+    def test_tx_ctrl(self):
+        """0: Takes 1 value. Edits CO tx_enable to be INPUT, last_enable based on input"""
+        tx_enable = self.node.od["tx_control"]["enable"]
+        last_enable = self.node.od["tx_control"]["last_enable_timestamp"]
+        tx_enable.value = False
+        last_enable.value = 0
+        start_time = int(time())
+
+        # enable
+        frame = make_packet_frame(EdlCommandCode.TX_CTRL, (True,))
+        self.mock_router.uplink_edl.put(frame)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+        self.assertEqual(response.code, EdlCommandCode.TX_CTRL)
+        self.assertEqual(response.values[0], (True))
+        self.assertEqual(tx_enable.value, True)
+        self.assertTrue(start_time >= last_enable.value)
+
+        # disable
+        frame = make_packet_frame(EdlCommandCode.TX_CTRL, (False,))
+        self.mock_router.uplink_edl.put(frame)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+        self.assertEqual(response.code, EdlCommandCode.TX_CTRL)
+        self.assertEqual(response.values[0], (False))
+        self.assertEqual(tx_enable.value, False)
+        self.assertEqual(last_enable.value, 0)
+
+    def test_soft_reset(self):
+        """1: No inputs. Should edit self.node.value_set_by_edl. Should not reply."""
+        self.node.value_set_by_edl = NodeStop.NO_STOP
+
+        frame = make_packet_frame(EdlCommandCode.C3_SOFT_RESET, ())
+        self.mock_router.uplink_edl.put(frame)
+        sleep(0.1)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        self.assertEqual(self.node.value_set_by_edl, NodeStop.SOFT_RESET)
+
+    def test_hard_reset(self):
+        """2: No inputs. Should edit self.node.value_set_by_edl. Should not reply."""
+        self.node.value_set_by_edl = NodeStop.NO_STOP
+
+        frame = make_packet_frame(EdlCommandCode.C3_HARD_RESET, ())
+        self.mock_router.uplink_edl.put(frame)
+        sleep(0.1)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        self.assertEqual(self.node.value_set_by_edl, NodeStop.HARD_RESET)
+
+    def test_factory_reset(self):
+        """3: No inputs. Should edit self.node.value_set_by_edl. Should not reply."""
+        self.node.value_set_by_edl = NodeStop.NO_STOP
+
+        frame = make_packet_frame(EdlCommandCode.C3_FACTORY_RESET, ())
+        self.mock_router.uplink_edl.put(frame)
+        sleep(0.1)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        self.assertEqual(self.node.value_set_by_edl, NodeStop.FACTORY_RESET)
+
     def test_opd_node_enable(self):
+        """11: Takes 2 values, nodeid and value. Sends two commands to test both states."""
+        self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.DISABLED
+
+        # enable
         frame = make_packet_frame(EdlCommandCode.OPD_ENABLE, (0x1C, True))
         self.mock_router.uplink_edl.put(frame)
-        time.sleep(0.3)
-        # assert queue not empty
         resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
-        # assert queue empty
+        self.assertTrue(self.mock_router.downlink_edl.empty())
         response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
         self.assertEqual(response.code,EdlCommandCode.OPD_ENABLE)
         self.assertEqual(response.values[0],(0x1))
         self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].status, OpdNodeState.ENABLED)
 
+        # disable
+        frame = make_packet_frame(EdlCommandCode.OPD_ENABLE, (0x1C, False))
+        self.mock_router.uplink_edl.put(frame)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+        self.assertEqual(response.code,EdlCommandCode.OPD_ENABLE)
+        self.assertEqual(response.values[0],(0x0))
+        self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].status, OpdNodeState.DISABLED)
 
 
+class MockMasterNode(MasterNode):
+    """MasterNode wrapper with an overwritten stop function. No type definitions to limit imports"""
+    def __init__(
+        self,
+        network,
+        od,
+        od_db,
+    ) -> None:
+        super().__init__(network, od, od_db)
+
+    def stop(self, reset: NodeStop | None = None):
+        self.value_set_by_edl = reset
 
 
 class MockNodeFlasherService(NodeFlasherService):
@@ -114,6 +202,17 @@ class MockChannelRouterService(ChannelRouterService):
             return self.uplink_edl
         elif vcid == 1:
             return self.uplink_cfdp
+
+
+class MockBeaconService(BeaconService):
+    def __init__(self):
+        self.told_to_beacon = False
+
+    def __del__(self):
+        pass
+
+    def send(self):
+        self.told_to_beacon = True
 
 
 class MockNode():
@@ -170,13 +269,3 @@ class MockNodeManagerService(NodeManagerService):
     def __del__(self):
         pass
 
-
-class MockBeaconService(BeaconService):
-    def __init__(self):
-        self.told_to_beacon = False
-
-    def __del__(self):
-        pass
-
-    def send(self):
-        self.told_to_beacon = True

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -5,6 +5,8 @@ Creats a lot of mock classes that report values so that we know that, as well as
 returning correctly, the commands have the desired result.
 """
 
+from __future__ import annotations
+
 import unittest
 from queue import SimpleQueue
 from time import sleep, time
@@ -467,7 +469,7 @@ class MockMasterNode(MasterNode):
         super().__init__(network, od, od_db)
         self.should_fail_test = False
 
-    def stop(self, reset: NodeStop):
+    def stop(self, reset: NodeStop | None = None):
         """
         FIXME: This should be `def stop(self, reset: NodeStop | None = None):` but the git testing
         environment uses an older version of python that does not support it. This should be changed

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -1,0 +1,182 @@
+"""Class to test that the edl service is handling commands correctly"""
+
+import time
+import unittest
+from queue import SimpleQueue
+from typing import Optional
+
+from olaf import CanNetwork, MasterNode
+from oresat_configs import Mission, OreSatConfig
+from spacepackets.uslp import TransferFrame
+
+from oresat_c3.protocols.edl_command import EdlCommandCode, EdlCommandRequest, EdlCommandResponse
+from oresat_c3.protocols.edl_packet import EdlPacket, EdlVcid
+from oresat_c3.protocols.uslp import make_frame, unpack_frame
+from oresat_c3.services.beacon import BeaconService
+from oresat_c3.services.channel_router import ChannelRouterService
+from oresat_c3.services.edl import EdlService
+from oresat_c3.services.node_flasher import NodeFlasherService
+from oresat_c3.services.node_manager import NodeManagerService
+from oresat_c3.subsystems.opd import OpdNodeState
+
+HMAC = bytes(32)
+
+def make_packet_frame(cmd: EdlCommandCode, values: tuple) -> TransferFrame:
+    payload = EdlCommandRequest(cmd, values).pack()
+    return make_frame(payload, 0, 1, hmac_key=HMAC)
+
+class TestEdl(unittest.TestCase):
+    """Test the C3 state service."""
+
+    def setUp(self):
+        self.mock_node_mgr = MockNodeManagerService()
+        self.beacon = MockBeaconService()
+        self.mock_router = MockChannelRouterService()
+        self.mock_flasher = MockNodeFlasherService()
+
+        config = OreSatConfig(Mission.default())
+        self.od = config.od_db["c3"]
+        network = CanNetwork("virtual", "vcan0")
+        self.node = MasterNode(network, self.od, config.od_db)
+
+        self.service = EdlService(
+            self.node, self.mock_node_mgr, self.beacon, self.mock_router, self.mock_flasher
+        )
+
+        self.node._setup_node()
+
+        # initial the service, but stop the thread
+        self.service.start(self.node)
+
+    def tearDown(self):
+        self.node._destroy_node()
+        self.service._event.set()
+        self.service.stop()
+
+    def test_opd_node_enable(self):
+        frame = make_packet_frame(EdlCommandCode.OPD_ENABLE, (0x1C, True))
+        self.mock_router.uplink_edl.put(frame)
+        time.sleep(0.3)
+        # assert queue not empty
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        # assert queue empty
+        response = EdlPacket.from_frame(unpack_frame(resp_raw), HMAC).payload
+        self.assertEqual(response.code,EdlCommandCode.OPD_ENABLE)
+        self.assertEqual(response.values[0],(0x1))
+        self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].status, OpdNodeState.ENABLED)
+
+
+
+
+
+class MockNodeFlasherService(NodeFlasherService):
+    """Cut down node flasher service to test if commands have the desired effect"""
+    def __init__(self):
+        self.told_to_flash = False
+
+    def __del__(self):
+        pass
+
+    def enqueue_flash(
+        self,
+        node_id: int,
+        filename: str,
+        throttle_delay: Optional[float] = None,
+        block_transfer: Optional[bool] = None,
+        request_crc: Optional[bool] = None,
+        confirm_image: Optional[bool] = None,
+    ):
+        # should this try to keep track of what node was flashed?
+        self.told_to_flash = True
+
+
+class MockChannelRouterService(ChannelRouterService):
+    """Cut down channel router with queues to make sure responses are correct."""
+    def __init__(self):
+        self.uplink_edl = SimpleQueue()
+        self.uplink_cfdp = SimpleQueue()
+        self.downlink_edl = SimpleQueue()
+        self.downlink_cfdp = SimpleQueue()
+
+    def __del__(self):
+        pass
+
+    def request_downlink_route(self, vcid: EdlVcid) -> SimpleQueue[bytes]:
+        if vcid == 0:
+            return self.downlink_edl
+        elif vcid == 1:
+            return self.downlink_cfdp
+
+    def request_uplink_route(
+        self, vcid: EdlVcid, use_cop: bool = False
+    ) -> SimpleQueue[TransferFrame]:
+        if vcid == 0:
+            return self.uplink_edl
+        elif vcid == 1:
+            return self.uplink_cfdp
+
+
+class MockNode():
+            def __init__(self) -> None:
+                self.status = OpdNodeState.NOT_FOUND
+
+            def enable(self) -> OpdNodeState:
+                self.status = OpdNodeState.ENABLED
+                return self.status
+
+            def disable(self) -> OpdNodeState:
+                self.status = OpdNodeState.DISABLED
+                return self.status
+
+            def probe(self) -> bool:
+                return self.status == OpdNodeState.NOT_FOUND
+
+            def reset(self) -> OpdNodeState:
+                self.status = OpdNodeState.ENABLED
+                return self.status
+
+
+class MockOpd():
+        def __init__(self):
+            self.enabled = False
+            self._nodes: dict[str, MockNode] = {}
+            self._nodes["star_tracker_1"] = MockNode()
+
+        def __getitem__(self, name: str) -> MockNode:
+            return self._nodes[name]
+
+        def enable(self):
+            self.enabled = True
+
+        def disable(self):
+            self.enabled = True
+
+        def scan(self) -> int:
+            return 1
+
+
+class MockNodeManagerService(NodeManagerService):
+    """
+    Cut down node manager that keeps track of last command. Will only contain information for star
+    tracker 1 (arbitrary), and so if further tests are desired this should be changed.
+    """
+    def __init__(self):
+        self.set_node = 0x0
+        self.set_state = 0x0
+        self.opd_addr_to_name = {0x1C: "star_tracker_1"}
+        self.node_id_to_name = {0x1C: "star_tracker_1"}
+        self.opd = MockOpd()
+
+    def __del__(self):
+        pass
+
+
+class MockBeaconService(BeaconService):
+    def __init__(self):
+        self.told_to_beacon = False
+
+    def __del__(self):
+        pass
+
+    def send(self):
+        self.told_to_beacon = True

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -123,9 +123,14 @@ class TestEdl(unittest.TestCase):
         self.assertTrue(self.mock_router.downlink_edl.empty())
         self.assertEqual(self.node.value_set_by_edl, NodeStop.FACTORY_RESET)
 
-    def test_co_node_enable_reset(self):
-        """4: Vestigal and no longer used."""
-        pass
+    def test_co_node_enable(self):
+        """
+        4: Unused commnad. NOTE: If you've replaced this command and this test now fails, please add
+        a test case here.
+        """
+        make_cmd(EdlCommandCode(4), (), self.mock_router.uplink_edl)
+        sleep(1)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
 
     def test_co_node_status(self):
         """5: 1 input. returns the heartbeat status of the relevant node."""
@@ -352,7 +357,7 @@ class TestEdl(unittest.TestCase):
         self.assertEqual(self.beacon.told_to_beacon, True)
 
     def test_ping(self):
-        """15: No input. Tests to make sure that calling send_tpdo is occurs, not that it works."""
+        """17: No input. Tests to make sure that calling send_tpdo is occurs, not that it works."""
         val = 536
 
         make_cmd(EdlCommandCode.PING, (val,), self.mock_router.uplink_edl)
@@ -362,7 +367,96 @@ class TestEdl(unittest.TestCase):
         self.assertEqual(response.code, EdlCommandCode.PING)
         self.assertEqual(response.values[0], val)
 
+    def test_rx_test(self):
+        """18: No input. No output. Test is that the c3 doesn't complain when it gets it."""
+        make_cmd(EdlCommandCode.RX_TEST, (), self.mock_router.uplink_edl)
+        sleep(1)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
 
+    def test_co_sdo_read_local(self):
+        """19: 3 inputs. 3 outputs. Tests reading a c3 index."""
+        od_val = self.node.od["reset_timeout"]
+        od_val.value = 10000
+
+        make_cmd(EdlCommandCode.CO_SDO_READ, (0x1,0x4001,0x0), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SDO_READ)
+        self.assertEqual(response.values[0], (0x1))
+        self.assertEqual(response.values[1], (0x4001))
+        self.assertEqual(response.values[2], (0x0))
+        self.assertEqual(response.values[3], (0x0))
+        self.assertEqual(response.values[4], (0x4))
+        self.assertEqual(int.from_bytes(response.values[5], "little"), (10000))
+
+    def test_co_sdo_read_remote(self):
+        """19: 3 inputs. 3 outputs. Tests reading a remote index."""
+        self.node.should_fail_test = False
+
+        make_cmd(
+            EdlCommandCode.CO_SDO_READ,
+            (0x2C,0x4000,0x0),
+            self.mock_router.uplink_edl
+        )
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SDO_READ)
+        self.assertEqual(response.values[0], (0x2C))
+        self.assertEqual(response.values[1], (0x4000))
+        self.assertEqual(response.values[2], (0x0))
+        self.assertEqual(response.values[3], (0x0))
+        self.assertEqual(response.values[4], (0x1))
+        self.assertEqual(int.from_bytes(response.values[5], "little"), (3))
+
+    def test_co_sdo_read_fail(self):
+        """19: 3 inputs. 3 outputs. Tests failing to read a remote index."""
+        self.node.should_fail_test = True
+
+        make_cmd(
+            EdlCommandCode.CO_SDO_READ,
+            (0x2C,0x4000,0x0),
+            self.mock_router.uplink_edl
+        )
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_SDO_READ)
+        self.assertEqual(response.values[0], (0x2C))
+        self.assertEqual(response.values[1], (0x4000))
+        self.assertEqual(response.values[2], (0x0))
+        self.assertEqual(response.values[3], (0x05040000))
+        self.assertEqual(response.values[4], (0x5))
+        self.assertEqual(response.values[5].decode("utf-8"), "ERROR")
+
+    def test_co_node_flash(self):
+        """20: 2-6 inputs. 1 output."""
+        make_cmd(
+            EdlCommandCode.CO_NODE_FLASH,
+            (0x2C,"name1",536,True,False,True),
+            self.mock_router.uplink_edl
+        )
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.CO_NODE_FLASH)
+        self.assertEqual(response.values[0], True)
+        self.assertEqual(self.mock_flasher.nid, 0x2C)
+        self.assertEqual(self.mock_flasher.fname, "name1")
+        self.assertEqual(self.mock_flasher.throttle, 536)
+        self.assertEqual(self.mock_flasher.blk, True)
+        self.assertEqual(self.mock_flasher.crc, False)
+        self.assertEqual(self.mock_flasher.conf, True)
+        self.assertEqual(self.mock_flasher.told_to_flash, True)
+
+    def test_no_new_cmds(self):
+        """
+        NOTE: If you add a new command and fail this test, please add tests for the new command
+        and increment this value.
+        """
+        NUMBER_OF_COMMANDS=21
+        self.assertEqual(len(EdlCommandCode),NUMBER_OF_COMMANDS)
 
 
 class MockMasterNode(MasterNode):
@@ -390,6 +484,13 @@ class MockMasterNode(MasterNode):
         if self.should_fail_test:
             raise SdoAbortedError(0x05040000)
 
+    def sdo_read(
+        self, key: str, index: int | str, subindex: int | str | None
+    ) -> str | float | bytes | bool:
+        if self.should_fail_test:
+            raise SdoAbortedError(0x05040000)
+        return 3
+
     def send_sync(self):
         self.value_set_by_edl = True
 
@@ -414,7 +515,12 @@ class MockNodeFlasherService(NodeFlasherService):
         request_crc: Optional[bool] = None,
         confirm_image: Optional[bool] = None,
     ):
-        # should this try to keep track of what node was flashed?
+        self.nid = node_id
+        self.fname = filename
+        self.throttle = throttle_delay
+        self.blk = block_transfer
+        self.crc = request_crc
+        self.conf = confirm_image
         self.told_to_flash = True
 
 

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -23,7 +23,7 @@ from oresat_c3.services.channel_router import ChannelRouterService
 from oresat_c3.services.edl import EdlService
 from oresat_c3.services.node_flasher import NodeFlasherService
 from oresat_c3.services.node_manager import NodeManagerService
-from oresat_c3.subsystems.opd import OpdNodeState
+from oresat_c3.subsystems.opd import OpdNodeState, OpdState
 
 HMAC = bytes(32)
 
@@ -207,10 +207,58 @@ class TestEdl(unittest.TestCase):
         self.assertEqual(response.values[0], True)
         self.assertEqual(self.node.value_set_by_edl, True)
 
+    def test_opd_sysenable(self):
+        """8: 1 input. Enables or disables the OPD."""
+        self.mock_node_mgr.opd.enabled = False
 
+        # enable
+        make_cmd(EdlCommandCode.OPD_SYSENABLE, (True,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_SYSENABLE)
+        self.assertEqual(response.values[0], (0x1))
+        self.assertEqual(self.mock_node_mgr.opd.enabled, True)
 
+        # disable
+        make_cmd(EdlCommandCode.OPD_SYSENABLE, (False,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_SYSENABLE)
+        self.assertEqual(response.values[0], (0x0))
+        self.assertEqual(self.mock_node_mgr.opd.enabled, False)
 
+    def test_opd_scan(self):
+        """9. No inputs. Should return 2 in this test setup."""
+        make_cmd(EdlCommandCode.OPD_SCAN, None, self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_SCAN)
+        self.assertEqual(response.values[0], 2)
 
+    def test_opd_probe(self):
+        """10. 1 input. returns if the node was found."""
+        self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.DISABLED
+
+        # found
+        make_cmd(EdlCommandCode.OPD_PROBE, (0x1C,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_PROBE)
+        self.assertEqual(response.values[0], True)
+
+        self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.NOT_FOUND
+
+        # not found
+        make_cmd(EdlCommandCode.OPD_PROBE, (0x1C,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_PROBE)
+        self.assertEqual(response.values[0], False)
 
     def test_opd_node_enable(self):
         """11: Takes 2 values, nodeid and value. Sends two commands to test both states."""
@@ -234,7 +282,41 @@ class TestEdl(unittest.TestCase):
         self.assertEqual(response.values[0], (0x0))
         self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].status, OpdNodeState.DISABLED)
 
+    def test_opd_reset(self):
+        """12. 1 input. returns if the node state value."""
+        self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.DISABLED
+        self.mock_node_mgr.opd["star_tracker_1"].was_reset = False
 
+        # found
+        make_cmd(EdlCommandCode.OPD_RESET, (0x1C,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_RESET)
+        self.assertEqual(response.values[0], 0x1)
+        self.assertEqual(self.mock_node_mgr.opd["star_tracker_1"].was_reset, True)
+
+    def test_opd_status(self):
+        """13. 1 input. returns if the node state value."""
+        self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.ENABLED
+
+        # enabled
+        make_cmd(EdlCommandCode.OPD_STATUS, (0x1C,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_STATUS)
+        self.assertEqual(response.values[0], 0x1)
+
+        self.mock_node_mgr.opd["star_tracker_1"].status = OpdNodeState.DISABLED
+
+        # disabled
+        make_cmd(EdlCommandCode.OPD_STATUS, (0x1C,), self.mock_router.uplink_edl)
+        resp_raw = self.mock_router.downlink_edl.get(timeout=1.0)
+        self.assertTrue(self.mock_router.downlink_edl.empty())
+        response = to_response(resp_raw)
+        self.assertEqual(response.code, EdlCommandCode.OPD_STATUS)
+        self.assertEqual(response.values[0], 0x0)
 
 
 class MockMasterNode(MasterNode):
@@ -264,6 +346,7 @@ class MockMasterNode(MasterNode):
 
     def send_sync(self):
         self.value_set_by_edl = True
+
 
 class MockNodeFlasherService(NodeFlasherService):
     """Cut down node flasher service to test if commands have the desired effect"""
@@ -337,10 +420,11 @@ class MockNode():
 
             def probe(self) -> bool:
                 """intent is that status is manually set prior to CMD."""
-                return self.status
+                return self.status != OpdNodeState.NOT_FOUND
 
             def reset(self) -> OpdNodeState:
                 self.status = OpdNodeState.ENABLED
+                self.was_reset = True
                 return self.status
 
 
@@ -349,18 +433,21 @@ class MockOpd():
             self.enabled = False
             self._nodes: dict[str, MockNode] = {}
             self._nodes["star_tracker_1"] = MockNode()
+            self.status = OpdState.ENABLED
 
         def __getitem__(self, name: str) -> MockNode:
             return self._nodes[name]
 
         def enable(self):
             self.enabled = True
+            self.status = OpdState.ENABLED
 
         def disable(self):
-            self.enabled = True
+            self.enabled = False
+            self.status = OpdState.DISABLED
 
         def scan(self) -> int:
-            return 1
+            return 2
 
 
 class MockNodeManagerService(NodeManagerService):

--- a/tests/services/test_edl.py
+++ b/tests/services/test_edl.py
@@ -467,7 +467,12 @@ class MockMasterNode(MasterNode):
         super().__init__(network, od, od_db)
         self.should_fail_test = False
 
-    def stop(self, reset: NodeStop | None = None):
+    def stop(self, reset: NodeStop):
+        """
+        FIXME: This should be `def stop(self, reset: NodeStop | None = None):` but the git testing
+        environment uses an older version of python that does not support it. This should be changed
+        once the tests reflect the current python version.
+        """
         self.value_set_by_edl = reset
 
     def sdo_write(


### PR DESCRIPTION
Fixed a few issues with the edl command handling. Added new test class that attempt to ensure that each command is parsed and executed correctly. Made co_node_enable a noop command as it is no longer relevant. Added test that fails if a new command is added, intended to serve as a reminder to update this class.

I'm not the happiest with the test for rtc_set_time, as I couldn't find a clean way to hijack its function calls. If anyone has a better test, feel free to add it before this gets pushed.