### PR TITLE
docs: fix readthedocs builds after pyproject migration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install . --group dev
+        pip install . -r docs/requirements.txt
 
     # - name: Lint with Pylama
     #  if: always() && steps.dependencies.conclusion == 'success'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
     python: "3.9"
 
@@ -13,4 +13,6 @@ formats:
 
 python:
   install:
-    - requirements: requirements.txt
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+sphinxcontrib-mermaid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,6 @@ dev = [
     "build",
     "pylama[all,toml]",
     "ruff",
-    "sphinx",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-mermaid",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Read the Docs builds broke after migrating dependencies to pyproject.toml. Unfortunately, Read the Docs doesn't support dependency groups with pip, so docs dependencies have moved to `docs/requirements.txt`.

OS version is updated to latest LTS but I kept the Python version the same as the project.